### PR TITLE
chore: add cargo-llvm-cov CI gate (≥90% line coverage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Test
         run: cargo test --all-targets --all-features
 
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Coverage gate (≥90% lines)
+        run: cargo llvm-cov --all-targets --all-features --fail-under-lines 90
+
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
 


### PR DESCRIPTION
## Summary

- Adds `cargo-llvm-cov` install step via `taiki-e/install-action@cargo-llvm-cov`
- Runs `cargo llvm-cov --all-targets --all-features --fail-under-lines 90`
- CI fails if line coverage drops below 90%
- No production code changes, no new Cargo.toml dependencies

## Verification

CI step added after existing `cargo test` step.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)