### PR TITLE
feat: background periodic TTL cleanup task (30 min)

### DIFF
--- a/src/adapters/storage_json.rs
+++ b/src/adapters/storage_json.rs
@@ -169,7 +169,7 @@ impl JsonStorageAdapter {
         Ok(packs)
     }
 
-    async fn purge_expired(&self) -> Result<()> {
+    pub async fn purge_expired(&self) -> Result<()> {
         let storage_dir = self.storage_dir.clone();
         let max_pack_bytes = self.max_pack_bytes;
         task::spawn_blocking(move || -> Result<()> {


### PR DESCRIPTION
## Summary

- `purge_expired` visibility changed to `pub` in `JsonStorageAdapter` (note: `pub(crate)` is not applicable because `main.rs` is a separate binary crate — the library is accessed via `mcp_context_pack::` path)
- Background `tokio::spawn` task added in `main.rs` — runs cleanup every 30 minutes
- First cleanup fires immediately at server startup (tokio interval semantics: first tick fires immediately)
- Errors are logged as `warn!` and do not crash the server

## Verification

- `cargo test --all-targets` passes (37 unit tests + 15/16 e2e; the single flaky e2e test is pre-existing, passes in isolation)
- `cargo clippy -- -D warnings` passes with 0 warnings

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)