### PR TITLE
chore: replace once_cell with std::sync::LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,6 @@ dependencies = [
  "async-trait",
  "chrono",
  "fs2",
- "once_cell",
  "rand",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ regex = "1"
 rand = { version = "0.8", features = ["std", "std_rng"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-once_cell = "1.20"
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/src/domain/types.rs
+++ b/src/domain/types.rs
@@ -1,18 +1,18 @@
 use super::errors::{DomainError, Result};
-use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::path::{Component, Path};
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 pub const CURRENT_SCHEMA_VERSION: u32 = 2;
 pub const MAX_REF_LINE_SPAN: usize = 2_000;
 
-static TOKEN_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[a-z0-9][a-z0-9_\-]{1,63}$").expect("token regex must compile"));
-static PACK_ID_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^pk_[a-z2-7]{8}$").expect("pack id regex must compile"));
+static TOKEN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-z0-9][a-z0-9_\-]{1,63}$").expect("token regex must compile"));
+static PACK_ID_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^pk_[a-z2-7]{8}$").expect("pack id regex must compile"));
 
 // ── PackId ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Replaced all `once_cell::sync::Lazy` usages with `std::sync::LazyLock`
- Removed `once_cell` from Cargo.toml dependencies
- No behavior change — identical semantics, one fewer dependency

## Verification
- `cargo test --all-targets` passes (pre-existing unrelated failure in `e2e_shutdown_notification_has_no_side_effects` also present on `main`)
- `cargo clippy -- -D warnings` passes with zero warnings

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)