### PR TITLE
fix: add DomainError::PackIdConflict for precise retry semantics

### DIFF
--- a/src/adapters/mcp_stdio/error_contract.rs
+++ b/src/adapters/mcp_stdio/error_contract.rs
@@ -24,6 +24,7 @@ pub(super) fn domain_error_response(id: Value, err: &DomainError) -> RpcEnvelope
         DomainError::MigrationRequired(_) => {
             ("migration_required", "migration_required", Value::Null)
         }
+        DomainError::PackIdConflict(_) => ("conflict", "pack_id_conflict", Value::Null),
     };
 
     let mut payload = json!({

--- a/src/adapters/storage_json.rs
+++ b/src/adapters/storage_json.rs
@@ -230,10 +230,7 @@ impl PackRepositoryPort for JsonStorageAdapter {
             let path = Self::pack_path(&storage_dir, &pack.id);
             if path.exists() {
                 lock.unlock().ok();
-                return Err(DomainError::Conflict(format!(
-                    "pack id '{}' already exists",
-                    pack.id
-                )));
+                return Err(DomainError::PackIdConflict(pack.id.to_string()));
             }
 
             if let Some(new_name) = &pack.name {

--- a/src/app/input_usecases.rs
+++ b/src/app/input_usecases.rs
@@ -180,11 +180,7 @@ impl InputUseCases {
 
             match self.repo.create_new(&pack).await {
                 Ok(()) => return Ok(pack),
-                Err(DomainError::Conflict(msg))
-                    if msg.starts_with("pack id ") && msg.ends_with(" already exists") =>
-                {
-                    continue;
-                }
+                Err(DomainError::PackIdConflict(_)) => continue,
                 Err(e) => return Err(e),
             }
         }

--- a/src/domain/errors.rs
+++ b/src/domain/errors.rs
@@ -28,6 +28,9 @@ pub enum DomainError {
 
     #[error("schema migration required: {0}")]
     MigrationRequired(String),
+
+    #[error("pack id already exists: {0}")]
+    PackIdConflict(String),
 }
 
 pub type Result<T> = std::result::Result<T, DomainError>;


### PR DESCRIPTION
## Summary
- Added `DomainError::PackIdConflict(String)` variant to `errors.rs`
- `create_new()` in `storage_json.rs` now returns `PackIdConflict` on file-already-exists (was a generic `Conflict` with a string-pattern check)
- Retry loop in `input_usecases.rs` now matches on `DomainError::PackIdConflict(_)` — clean, exhaustive, no fragile string matching
- `error_contract.rs` updated with exhaustive match arm: maps `PackIdConflict` to kind=`conflict`, code=`pack_id_conflict`

## Verification
- `cargo test --all-targets` ✅ (13 tests pass)
- `cargo clippy -- -D warnings` ✅ (no warnings)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)