### PR TITLE
fix: add DomainError::Deserialize, correct serde_json error mapping

### DIFF
--- a/src/adapters/mcp_stdio/error_contract.rs
+++ b/src/adapters/mcp_stdio/error_contract.rs
@@ -21,6 +21,7 @@ pub(super) fn domain_error_response(id: Value, err: &DomainError) -> RpcEnvelope
         DomainError::InvalidState(_) => ("invalid_state", "invalid_state", Value::Null),
         DomainError::StaleRef(_) => ("stale_ref", "stale_ref", Value::Null),
         DomainError::Io(_) => ("io_error", "io_error", Value::Null),
+        DomainError::Deserialize(_) => ("deserialize_error", "deserialize_error", Value::Null),
         DomainError::MigrationRequired(_) => {
             ("migration_required", "migration_required", Value::Null)
         }

--- a/src/adapters/storage_json.rs
+++ b/src/adapters/storage_json.rs
@@ -66,7 +66,7 @@ impl JsonStorageAdapter {
             Err(DomainError::MigrationRequired(msg)) => Err(DomainError::MigrationRequired(
                 format!("{} [path={}]", msg, path.display()),
             )),
-            Err(err) => Err(DomainError::Io(format!(
+            Err(err) => Err(DomainError::Deserialize(format!(
                 "failed to decode pack '{}': {}",
                 path.display(),
                 err

--- a/src/domain/errors.rs
+++ b/src/domain/errors.rs
@@ -26,6 +26,9 @@ pub enum DomainError {
     #[error("{0}")]
     Io(String),
 
+    #[error("failed to deserialize: {0}")]
+    Deserialize(String),
+
     #[error("schema migration required: {0}")]
     MigrationRequired(String),
 }
@@ -40,6 +43,6 @@ impl From<std::io::Error> for DomainError {
 
 impl From<serde_json::Error> for DomainError {
     fn from(err: serde_json::Error) -> Self {
-        Self::Io(err.to_string())
+        Self::Deserialize(err.to_string())
     }
 }


### PR DESCRIPTION
## Summary
- Added `DomainError::Deserialize(String)` variant to `errors.rs`
- Fixed `From<serde_json::Error>` impl: was incorrectly mapping to `Io`, now correctly maps to `Deserialize`
- Fixed `decode_with_path` in `storage_json.rs`: non-migration parse failures now use `Deserialize` instead of `Io`
- Added `Deserialize` match arm to MCP `error_contract.rs` response handler with kind `"deserialize_error"` / code `"deserialize_error"`

Semantically correct separation: `Io` errors = filesystem/OS failures, `Deserialize` = JSON parse failures.

Closes #16

## Verification
- `cargo test --lib` ✅ (56 tests pass)
- `cargo clippy --all-targets -- -D warnings` ✅ (no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)