### PR TITLE
refactor: extract pack resolve() to shared app/resolver.rs

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
 pub mod input_usecases;
 pub mod output_usecases;
 pub mod ports;
+pub mod resolver;

--- a/src/app/resolver.rs
+++ b/src/app/resolver.rs
@@ -1,0 +1,49 @@
+use crate::{
+    app::ports::PackRepositoryPort,
+    domain::{
+        errors::{DomainError, Result},
+        models::Pack,
+        types::{PackId, PackName},
+    },
+};
+
+/// Resolve a pack by ID or name.
+///
+/// Algorithm:
+/// 1. Trim whitespace; reject empty identifiers.
+/// 2. If the identifier parses as a [`PackId`], look up by id.
+///    - Found → return it.
+///    - Not found → return [`DomainError::NotFound`] immediately (a valid UUID
+///      that has no match should not silently fall back to a name lookup).
+/// 3. Otherwise treat the identifier as a [`PackName`] and look up by name.
+///    - Found → return it.
+///    - Not found → return [`DomainError::NotFound`].
+pub async fn resolve_pack(repo: &dyn PackRepositoryPort, identifier: &str) -> Result<Pack> {
+    let identifier = identifier.trim();
+    if identifier.is_empty() {
+        return Err(DomainError::InvalidData(
+            "identifier (id or name) is required".into(),
+        ));
+    }
+
+    // Try by id first
+    if let Ok(id) = PackId::parse(identifier) {
+        if let Some(pack) = repo.get_by_id(&id).await? {
+            return Ok(pack);
+        }
+        return Err(DomainError::NotFound(format!(
+            "pack '{}' not found",
+            identifier
+        )));
+    }
+
+    // Fall back to name lookup
+    let name = PackName::new(identifier)?;
+    if let Some(pack) = repo.get_by_name(&name).await? {
+        return Ok(pack);
+    }
+    Err(DomainError::NotFound(format!(
+        "pack '{}' not found",
+        identifier
+    )))
+}


### PR DESCRIPTION
## Summary
- Created `src/app/resolver.rs` with `resolve_pack(repo, identifier) -> Result<Pack>`
- Removed duplicated resolve-by-id-or-name logic from both usecases
- Single source of truth for pack resolution semantics

## Changes
- `src/app/resolver.rs` (new): shared `resolve_pack` async function with full doc-comments explaining the three-step algorithm (empty check, ID lookup, name fallback)
- `src/app/mod.rs`: added `pub mod resolver;` export
- `src/app/input_usecases.rs`: private `resolve()` now delegates to `resolver::resolve_pack()`; unused inline logic removed
- `src/app/output_usecases.rs`: same — private `resolve()` delegates; `PackId`/`PackName` imports removed from this file

## Verification
- `cargo test --all-targets` ✅ (one pre-existing flaky e2e race passes when run in isolation)
- `cargo clippy -- -D warnings` ✅

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)