### PR TITLE
refactor: add purge_expired to PackRepositoryPort trait

### DIFF
--- a/src/adapters/storage_json.rs
+++ b/src/adapters/storage_json.rs
@@ -169,7 +169,7 @@ impl JsonStorageAdapter {
         Ok(packs)
     }
 
-    pub async fn purge_expired(&self) -> Result<()> {
+    async fn purge_expired_locked(&self) -> Result<()> {
         let storage_dir = self.storage_dir.clone();
         let max_pack_bytes = self.max_pack_bytes;
         task::spawn_blocking(move || -> Result<()> {
@@ -407,6 +407,10 @@ impl PackRepositoryPort for JsonStorageAdapter {
         })
         .await
         .map_err(|e| DomainError::Io(format!("task execution failed: {}", e)))?
+    }
+
+    async fn purge_expired(&self) -> Result<()> {
+        self.purge_expired_locked().await
     }
 }
 

--- a/src/app/ports.rs
+++ b/src/app/ports.rs
@@ -16,6 +16,7 @@ pub trait PackRepositoryPort: Send + Sync {
     async fn get_by_id(&self, id: &PackId) -> Result<Option<Pack>>;
     async fn get_by_name(&self, name: &PackName) -> Result<Option<Pack>>;
     async fn list_packs(&self, filter: ListFilter) -> Result<Vec<Pack>>;
+    async fn purge_expired(&self) -> Result<()>;
 }
 
 #[async_trait]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use mcp_context_pack::app::ports::PackRepositoryPort as _;
+
 fn source_root_from_env_or_cwd() -> PathBuf {
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 

--- a/tests/unit_output.rs
+++ b/tests/unit_output.rs
@@ -65,6 +65,10 @@ impl PackRepositoryPort for FakePackRepo {
     async fn list_packs(&self, _filter: ListFilter) -> Result<Vec<Pack>> {
         Ok(self.0.lock().unwrap().values().cloned().collect())
     }
+
+    async fn purge_expired(&self) -> Result<()> {
+        Ok(())
+    }
 }
 
 // ── FakeExcerptPort ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Added `async fn purge_expired(&self) -> Result<()>` to `PackRepositoryPort`
- Renamed inherent `JsonStorageAdapter::purge_expired` to `purge_expired_locked` and wired it into the trait impl to avoid name collision
- Added no-op `purge_expired` impl to `FakePackRepo` in tests
- Added `use mcp_context_pack::app::ports::PackRepositoryPort as _;` to `main.rs` so the trait method is in scope

## Verification
- `cargo test --all-targets` passes (104 tests)
- `cargo clippy -- -D warnings` clean

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)