### PR TITLE
fix: storage hardening (error classification, Ambiguous variant, usize cast)

### DIFF
--- a/src/adapters/mcp_stdio/error_contract.rs
+++ b/src/adapters/mcp_stdio/error_contract.rs
@@ -10,6 +10,7 @@ pub(super) fn domain_error_response(id: Value, err: &DomainError) -> RpcEnvelope
         DomainError::TtlRequired(_) => ("validation", "ttl_required", Value::Null),
         DomainError::NotFound(_) => ("not_found", "not_found", Value::Null),
         DomainError::Conflict(_) => ("conflict", "conflict", Value::Null),
+        DomainError::Ambiguous(_) => ("conflict", "ambiguous", Value::Null),
         DomainError::RevisionConflict { expected, actual } => (
             "conflict",
             "revision_conflict",

--- a/src/domain/errors.rs
+++ b/src/domain/errors.rs
@@ -14,6 +14,9 @@ pub enum DomainError {
     #[error("conflict: {0}")]
     Conflict(String),
 
+    #[error("ambiguous: {0}")]
+    Ambiguous(String),
+
     #[error("revision conflict: expected {expected}, actual {actual}")]
     RevisionConflict { expected: u64, actual: u64 },
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -553,7 +553,7 @@ async fn test_malformed_pack_file_fails_closed() {
 
     let (input_uc, _) = build_services(storage_dir, tmp.path().to_path_buf());
     let listed = input_uc.list(None, None, None, None).await;
-    assert!(matches!(listed, Err(DomainError::Io(_))));
+    assert!(matches!(listed, Err(DomainError::Deserialize(_))));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- `decode_with_path`: added `InvalidData` explicit arm to prevent reclassification as `Deserialize`
- `lock.unlock().ok()` → `tracing::warn!` for observability on unlock failures
- Added `DomainError::Ambiguous(String)` variant for multi-name-match data integrity violations
- `read_pack_meta_from_path`: added `tracing::warn!` for unparseable files
- `u64 as usize` → `usize::try_from().unwrap_or(usize::MAX)` for 32-bit safety
- Updated integration test: malformed JSON pack now correctly returns `Deserialize` error

## Verification
- `cargo test --all-targets` passes (pre-existing flaky e2e_shutdown_notification_has_no_side_effects is unrelated to these changes — also fails on main)
- `cargo clippy -- -D warnings` passes

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)