### PR TITLE
test: update malformed-pack test assertion for DomainError::Deserialize

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -553,7 +553,7 @@ async fn test_malformed_pack_file_fails_closed() {
 
     let (input_uc, _) = build_services(storage_dir, tmp.path().to_path_buf());
     let listed = input_uc.list(None, None, None, None).await;
-    assert!(matches!(listed, Err(DomainError::Io(_))));
+    assert!(matches!(listed, Err(DomainError::Deserialize(_))));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Verified `test_malformed_pack_file_fails_closed` assertion after wave-2 changes
- Updated error variant assertion from `DomainError::Io(_)` to `DomainError::Deserialize(_)` — serde_json errors now map to `Deserialize` via the `From<serde_json::Error>` impl, not `Io`
- All 19 integration tests pass

## Verification
- `cargo test --test integration_test` -- all 19 tests pass
- `cargo clippy --all-targets -- -D warnings` -- clean

Closes #31

Generated with [Claude Code](https://claude.com/claude-code)