### PR TITLE
Slice #58: freshness_state in list/get + stale-safe filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,17 @@ CONTEXT_PACK_MAX_SOURCE_BYTES = "2097152"
 - `create` requires `ttl_minutes`.
 - `touch_ttl` accepts exactly one: `ttl_minutes` or `extend_minutes`.
 - `output` actions stay `list|get` (no extra tool/action sprawl).
+- `input list` and `output list` accept optional `freshness` filter:
+  - `fresh`
+  - `expiring_soon`
+  - `expired`
+- Default list behavior is stale-safe: expired packs are hidden unless `freshness=expired` is requested explicitly.
 - `output get` additive args: `mode(full|compact)`, `limit`, `offset`, `cursor`, `match` (regex).
+- Freshness metadata is normalized and stable in list/get surfaces:
+  - `freshness_state`
+  - `expires_at`
+  - `ttl_remaining`
+- Human-readable output (`output list|get`) adds concise warnings for `expiring_soon` and `expired`.
 - Deterministic `output get(name=...)` resolution order:
   1. prefer `finalized` candidates over non-finalized;
   2. inside that status tier, pick latest `updated_at`;
@@ -269,10 +279,23 @@ Name-based read (deterministic/fail-closed):
 }
 ```
 
+List only expired packs (explicit stale surfacing):
+
+```json
+{
+  "name": "output",
+  "arguments": {
+    "action": "list",
+    "freshness": "expired"
+  }
+}
+```
+
 In successful output LEGEND, inspect:
 - `selected_by` (`exact_id` or name-based policy marker)
 - `selected_revision`
 - `selected_status`
+- `freshness_state` / `expires_at` / `ttl_remaining` (+ `warning` when stale risk is present)
 
 </details>
 
@@ -446,7 +469,17 @@ CONTEXT_PACK_MAX_SOURCE_BYTES = "2097152"
 - `create` требует `ttl_minutes`.
 - `touch_ttl` принимает строго одно: `ttl_minutes` или `extend_minutes`.
 - `output` остаётся с actions только `list|get` (без разрастания API).
+- `input list` и `output list` принимают опциональный фильтр `freshness`:
+  - `fresh`
+  - `expiring_soon`
+  - `expired`
+- Поведение list по умолчанию stale-safe: expired-пакеты скрыты, пока явно не запрошен `freshness=expired`.
 - Дополнительные аргументы `output get`: `mode(full|compact)`, `limit`, `offset`, `cursor`, `match` (regex).
+- В list/get добавлена нормализованная freshness-мета в стабильной форме:
+  - `freshness_state`
+  - `expires_at`
+  - `ttl_remaining`
+- В человекочитаемом выводе (`output list|get`) добавляются краткие предупреждения для `expiring_soon` и `expired`.
 - Детерминированное разрешение `output get(name=...)`:
   1. приоритет `finalized` над не-finalized;
   2. внутри выбранного статуса — максимальный `updated_at`;
@@ -508,9 +541,22 @@ CONTEXT_PACK_MAX_SOURCE_BYTES = "2097152"
 }
 ```
 
+Показать только expired-пакеты (явное surfacing stale):
+
+```json
+{
+  "name": "output",
+  "arguments": {
+    "action": "list",
+    "freshness": "expired"
+  }
+}
+```
+
 В успешном LEGEND проверяйте:
 - `selected_by` (`exact_id` или маркер name-политики)
 - `selected_revision`
 - `selected_status`
+- `freshness_state` / `expires_at` / `ttl_remaining` (+ `warning`, когда есть риск stale)
 
 </details>

--- a/src/adapters/mcp_stdio/schema.rs
+++ b/src/adapters/mcp_stdio/schema.rs
@@ -31,6 +31,11 @@ pub(super) fn tools_schema() -> Value {
                         "extend_minutes": { "type": "integer", "description": "Extend existing TTL by this many minutes (touch_ttl)." },
                         "expected_revision": { "type": "integer", "description": "Required for mutating actions to prevent lost updates." },
                         "status": { "type": "string", "enum": ["draft", "finalized"] },
+                        "freshness": {
+                            "type": "string",
+                            "enum": ["fresh", "expiring_soon", "expired"],
+                            "description": "Optional list filter by freshness state."
+                        },
                         "query": { "type": "string", "description": "Text search for list" },
                         "limit": { "type": "integer" },
                         "offset": { "type": "integer" },
@@ -67,6 +72,11 @@ pub(super) fn tools_schema() -> Value {
                             "type": "string",
                             "enum": ["draft", "finalized"],
                             "description": "Optional status filter (for list and get)"
+                        },
+                        "freshness": {
+                            "type": "string",
+                            "enum": ["fresh", "expiring_soon", "expired"],
+                            "description": "Optional freshness filter for list."
                         },
                         "mode": {
                             "type": "string",

--- a/src/app/input_usecases.rs
+++ b/src/app/input_usecases.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::{
     app::{
-        ports::{CodeExcerptPort, ListFilter, PackRepositoryPort},
+        ports::{CodeExcerptPort, FreshnessState, ListFilter, PackRepositoryPort},
         resolver::resolve_pack,
     },
     domain::{
@@ -118,9 +118,22 @@ impl InputUseCases {
         limit: Option<usize>,
         offset: Option<usize>,
     ) -> Result<Vec<Pack>> {
+        self.list_with_freshness(status, query, limit, offset, None)
+            .await
+    }
+
+    pub async fn list_with_freshness(
+        &self,
+        status: Option<Status>,
+        query: Option<String>,
+        limit: Option<usize>,
+        offset: Option<usize>,
+        freshness: Option<FreshnessState>,
+    ) -> Result<Vec<Pack>> {
         self.repo
             .list_packs(ListFilter {
                 status,
+                freshness,
                 query,
                 limit,
                 offset,


### PR DESCRIPTION
## Summary
- add normalized `freshness_state` (`fresh`/`expiring_soon`/`expired`) across list/get surfaces
- add stale-safe freshness filtering (`freshness`) in `input list` / `output list`, including explicit `freshness=expired` surfacing
- add stable get freshness metadata (`expires_at`, `ttl_remaining`, `freshness_state`) plus concise warnings for `expiring_soon`/`expired`
- extend tests (unit/integration/e2e) for freshness boundaries, filtering, metadata, and warnings
- document freshness filter + stale warnings in README (EN/RU)

## Scope guard
- Implements only issue #58 contract and addendum touch-surface.
- No changes to #60/#61/#62 logic.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `scripts/check_coverage_baseline.sh`
- `cargo audit`

Refs #58
Parent #57
