### PR TITLE
Slice #61: default compact handoff mode with full drill-down

### DIFF
--- a/src/adapters/mcp_stdio/schema.rs
+++ b/src/adapters/mcp_stdio/schema.rs
@@ -81,7 +81,7 @@ pub(super) fn tools_schema() -> Value {
                         "mode": {
                             "type": "string",
                             "enum": ["full", "compact"],
-                            "description": "Render mode for output get (default: full)"
+                            "description": "Render mode for output get (default: compact handoff page; use full for complete snippets)"
                         },
                         "query": { "type": "string", "description": "Optional text search for list" },
                         "cursor": { "type": "string", "description": "Opaque cursor returned by output get paging metadata" },


### PR DESCRIPTION
Closes #61

## Summary
- default `output get` now serves compact handoff mode with bounded page size for low-noise routing loops
- compact content now includes handoff summary blocks (objective/scope, verdict/status, top risks/gaps, freshness, deep-nav hints)
- full mode remains available for complete refs/anchors/snippets
- schema/docs updated to show compact-vs-full copy-paste usage and paging continuation

## Tests
- added mode/default semantics coverage in `tool_output` unit tests
- added compact summary + size assertions in integration tests
- added E2E coverage for default compact bounded paging and full drill-down preservation

## Required gates (local)
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features
- scripts/check_coverage_baseline.sh
- cargo audit
