### PR TITLE
Slice #60: fail-closed finalize quality gate with structured errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,21 @@ CONTEXT_PACK_MAX_SOURCE_BYTES = "2097152"
 - `match` invalid regex returns validation error (`invalid_data`) with explicit reason.
 - `output` is always markdown (`format` is rejected).
 
+### Finalize checklist (fail-closed)
+
+Before setting `status=finalized`, ensure:
+- `scope` section exists and has substance (description and/or refs/diagrams).
+- `findings` section exists and has substance (description and/or refs/diagrams).
+- `qa` section exists and contains a `verdict` field (for example: `verdict: pass`).
+- all refs are resolvable (no stale/broken anchors).
+
+If finalize validation fails, the error is returned as `finalize_validation` with structured details:
+- `missing_sections`
+- `missing_fields`
+- `invalid_refs` (section/ref/path/line range/reason)
+
+Draft workflow remains flexible: these checks are enforced only on finalize transition.
+
 ---
 
 ## CI and coverage policy (maintainers)
@@ -516,6 +531,21 @@ CONTEXT_PACK_MAX_SOURCE_BYTES = "2097152"
 - Cursor fail-closed: при stale/mismatch возвращается `invalid_data` с семантикой `invalid_cursor` в message.
 - Невалидный regex в `match` возвращает validation error (`invalid_data`) с явной причиной.
 - `output` всегда markdown (`format` отклоняется).
+
+### Finalize checklist (fail-closed)
+
+Перед установкой `status=finalized` убедитесь:
+- есть секция `scope` с содержимым (description и/или refs/diagrams);
+- есть секция `findings` с содержимым (description и/или refs/diagrams);
+- есть секция `qa`, где присутствует поле `verdict` (например: `verdict: pass`);
+- все refs резолвятся (нет stale/broken anchors).
+
+Если валидация финализации не проходит, возвращается `finalize_validation` со структурированными деталями:
+- `missing_sections`
+- `missing_fields`
+- `invalid_refs` (section/ref/path/line range/reason)
+
+Черновой workflow остаётся гибким: эти проверки применяются только при переходе в finalized.
 
 ---
 

--- a/src/adapters/mcp_stdio/error_contract.rs
+++ b/src/adapters/mcp_stdio/error_contract.rs
@@ -26,6 +26,20 @@ pub(super) fn domain_error_response(id: Value, err: &DomainError) -> RpcEnvelope
             }),
         ),
         DomainError::InvalidState(_) => ("invalid_state", "invalid_state", Value::Null),
+        DomainError::FinalizeValidation {
+            missing_sections,
+            missing_fields,
+            invalid_refs,
+            ..
+        } => (
+            "invalid_state",
+            "finalize_validation",
+            json!({
+                "missing_sections": missing_sections,
+                "missing_fields": missing_fields,
+                "invalid_refs": invalid_refs,
+            }),
+        ),
         DomainError::StaleRef(_) => ("stale_ref", "stale_ref", Value::Null),
         DomainError::Io(_) => ("io_error", "io_error", Value::Null),
         DomainError::Deserialize(_) => ("deserialize_error", "deserialize_error", Value::Null),

--- a/src/domain/errors.rs
+++ b/src/domain/errors.rs
@@ -1,4 +1,15 @@
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FinalizeRefIssue {
+    pub section_key: String,
+    pub ref_key: String,
+    pub path: String,
+    pub line_start: usize,
+    pub line_end: usize,
+    pub reason: String,
+}
 
 #[derive(Debug, Error)]
 pub enum DomainError {
@@ -25,6 +36,14 @@ pub enum DomainError {
 
     #[error("invalid state: {0}")]
     InvalidState(String),
+
+    #[error("finalize validation failed: {message}")]
+    FinalizeValidation {
+        message: String,
+        missing_sections: Vec<String>,
+        missing_fields: Vec<String>,
+        invalid_refs: Vec<FinalizeRefIssue>,
+    },
 
     #[error("stale ref: {0}")]
     StaleRef(String),


### PR DESCRIPTION
Closes #60

## Summary
- enforce fail-closed finalize checklist: required `scope`, `findings`, and `qa` sections, with explicit `qa.verdict`
- keep draft workflow flexible: finalize checks are enforced only on Draft -> Finalized transition
- return structured actionable finalize validation errors (`missing_sections`, `missing_fields`, `invalid_refs`)
- validate ref integrity at finalize and block stale/broken anchors with section/ref/path/line details
- update README with finalize checklist and error details (EN/RU)

## Tests
- domain finalize gate tests (positive + negative)
- integration tests for missing sections/fields, stale refs, and draft flexibility
- e2e test for structured finalize validation details + existing finalize success path updated

## Required gates (local)
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features
- scripts/check_coverage_baseline.sh
- cargo audit
