### PR TITLE
S1 #71: v3 contract cutover for schema + tool routing

### DIFF
--- a/src/adapters/mcp_stdio/schema.rs
+++ b/src/adapters/mcp_stdio/schema.rs
@@ -5,21 +5,27 @@ pub(super) fn tools_schema() -> Value {
         "tools": [
             {
                 "name": "input",
-                "description": "Manage context packs: create/update/get/list, mutate sections/refs/diagrams, and update status/meta.",
+                "description": "Manage context packs with v3 actions: list/get/write/ttl/delete.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "action": {
                             "type": "string",
                             "description": "Operation to perform",
+                            "enum": ["list", "get", "write", "ttl", "delete"]
+                        },
+                        "op": {
+                            "type": "string",
+                            "description": "Write operation kind (v3 transitional router).",
                             "enum": [
-                                "list", "create", "get",
-                                "upsert_section", "delete_section",
-                                "upsert_ref", "delete_ref",
+                                "create",
+                                "upsert_section",
+                                "delete_section",
+                                "upsert_ref",
+                                "delete_ref",
                                 "upsert_diagram",
-                                "set_meta", "set_status",
-                                "delete_pack",
-                                "touch_ttl"
+                                "set_meta",
+                                "set_status"
                             ]
                         },
                         "id": { "type": "string", "description": "Pack ID" },
@@ -27,9 +33,9 @@ pub(super) fn tools_schema() -> Value {
                         "title": { "type": "string" },
                         "brief": { "type": "string", "description": "Short description of the pack" },
                         "tags": { "type": "array", "items": { "type": "string" } },
-                        "ttl_minutes": { "type": "integer", "description": "TTL from now in minutes. Required for create; also used by touch_ttl(set)." },
-                        "extend_minutes": { "type": "integer", "description": "Extend existing TTL by this many minutes (touch_ttl)." },
-                        "expected_revision": { "type": "integer", "description": "Required for mutating actions to prevent lost updates." },
+                        "ttl_minutes": { "type": "integer", "description": "TTL from now in minutes. Required for op=create; also used by action=ttl(set)." },
+                        "extend_minutes": { "type": "integer", "description": "Extend existing TTL by this many minutes (action=ttl)." },
+                        "expected_revision": { "type": "integer", "description": "Required for mutating actions: write/ttl." },
                         "status": { "type": "string", "enum": ["draft", "finalized"] },
                         "freshness": {
                             "type": "string",
@@ -58,13 +64,13 @@ pub(super) fn tools_schema() -> Value {
             },
             {
                 "name": "output",
-                "description": "Render a context pack with real code excerpts in Markdown, or list packs.",
+                "description": "Render v3 output actions: list/read.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "action": {
                             "type": "string",
-                            "enum": ["list", "get"]
+                            "enum": ["list", "read"]
                         },
                         "id": { "type": "string", "description": "Pack ID" },
                         "name": { "type": "string", "description": "Pack name" },

--- a/src/adapters/mcp_stdio/tool_input.rs
+++ b/src/adapters/mcp_stdio/tool_input.rs
@@ -40,119 +40,13 @@ pub(super) async fn handle_input_tool(
                 }),
             )
         }
-        "create" => {
-            let name = str_opt(args, "name");
-            let title = str_opt(args, "title");
-            let brief = str_opt(args, "brief");
-            let tags = tags_opt(args)?;
-            let ttl_minutes = req_u64(args, "ttl_minutes")?;
-            let pack = uc
-                .create_with_tags_ttl(name, title, brief, tags, ttl_minutes)
-                .await?;
-            tool_success("create", serde_json::to_value(pack)?)
-        }
         "get" => {
             let ident = req_identifier(args)?;
             let pack = uc.get(&ident).await?;
             tool_success("get", pack_with_freshness_metadata(pack)?)
         }
-        "upsert_section" => {
-            reject_legacy_alias(args, "title", "section_title")?;
-            reject_legacy_alias(args, "description", "section_description")?;
-            let ident = req_identifier(args)?;
-            let expected_revision = req_u64(args, "expected_revision")?;
-            let section_key = req_str(args, "section_key")?;
-            let title = req_str(args, "section_title")?;
-            let description = str_opt(args, "section_description");
-            let order = usize_opt(args, "section_order")?;
-            let pack = uc
-                .upsert_section_checked(
-                    &ident,
-                    &section_key,
-                    title,
-                    description,
-                    order,
-                    expected_revision,
-                )
-                .await?;
-            tool_success("upsert_section", serde_json::to_value(pack)?)
-        }
-        "delete_section" => {
-            let ident = req_identifier(args)?;
-            let expected_revision = req_u64(args, "expected_revision")?;
-            let section_key = req_str(args, "section_key")?;
-            let pack = uc
-                .delete_section_checked(&ident, &section_key, expected_revision)
-                .await?;
-            tool_success("delete_section", serde_json::to_value(pack)?)
-        }
-        "upsert_ref" => {
-            reject_legacy_alias(args, "title", "ref_title")?;
-            reject_legacy_alias(args, "why", "ref_why")?;
-            let ident = req_identifier(args)?;
-            let expected_revision = req_u64(args, "expected_revision")?;
-            let req = UpsertRefRequest {
-                section_key: req_str(args, "section_key")?,
-                ref_key: req_str(args, "ref_key")?,
-                path: req_str(args, "path")?,
-                line_start: req_usize(args, "line_start")?,
-                line_end: req_usize(args, "line_end")?,
-                title: str_opt(args, "ref_title"),
-                why: str_opt(args, "ref_why"),
-                group: str_opt(args, "group"),
-            };
-            let pack = uc
-                .upsert_ref_checked(&ident, req, expected_revision)
-                .await?;
-            tool_success("upsert_ref", serde_json::to_value(pack)?)
-        }
-        "delete_ref" => {
-            let ident = req_identifier(args)?;
-            let expected_revision = req_u64(args, "expected_revision")?;
-            let section_key = req_str(args, "section_key")?;
-            let ref_key = req_str(args, "ref_key")?;
-            let pack = uc
-                .delete_ref_checked(&ident, &section_key, &ref_key, expected_revision)
-                .await?;
-            tool_success("delete_ref", serde_json::to_value(pack)?)
-        }
-        "upsert_diagram" => {
-            reject_legacy_alias(args, "why", "diagram_why")?;
-            let ident = req_identifier(args)?;
-            let expected_revision = req_u64(args, "expected_revision")?;
-            let request = UpsertDiagramRequest {
-                section_key: req_str(args, "section_key")?,
-                diagram_key: req_str(args, "diagram_key")?,
-                title: req_str(args, "title")?,
-                mermaid: req_str(args, "mermaid")?,
-                why: str_opt(args, "diagram_why"),
-            };
-            let pack = uc
-                .upsert_diagram_checked(&ident, request, expected_revision)
-                .await?;
-            tool_success("upsert_diagram", serde_json::to_value(pack)?)
-        }
-        "set_meta" => {
-            let ident = req_identifier(args)?;
-            let expected_revision = req_u64(args, "expected_revision")?;
-            let title = str_opt(args, "title");
-            let brief = str_opt(args, "brief");
-            let tags = tags_opt(args)?;
-            let pack = uc
-                .set_meta_checked(&ident, title, brief, tags, expected_revision)
-                .await?;
-            tool_success("set_meta", serde_json::to_value(pack)?)
-        }
-        "set_status" => {
-            let ident = req_identifier(args)?;
-            let expected_revision = req_u64(args, "expected_revision")?;
-            let status = req_status(args, "status")?;
-            let pack = uc
-                .set_status_checked(&ident, status, expected_revision)
-                .await?;
-            tool_success("set_status", serde_json::to_value(pack)?)
-        }
-        "touch_ttl" => {
+        "write" => handle_write_action(args, uc).await,
+        "ttl" => {
             let ident = req_identifier(args)?;
             let expected_revision = req_u64(args, "expected_revision")?;
             let ttl_minutes = u64_opt(args, "ttl_minutes")?;
@@ -174,23 +68,161 @@ pub(super) async fn handle_input_tool(
             let pack = uc
                 .touch_ttl_checked(&ident, expected_revision, mode)
                 .await?;
-            tool_success("touch_ttl", serde_json::to_value(pack)?)
+            tool_success("ttl", serde_json::to_value(pack)?)
         }
-        "delete_pack" => {
+        "delete" => {
             let id = req_str(args, "id")?;
             let deleted = uc.delete_pack_file(&id).await?;
             tool_success(
-                "delete_pack",
+                "delete",
                 serde_json::json!({
                     "id": id,
                     "deleted": deleted
                 }),
             )
         }
+        _ => Err(unsupported_input_action(action)),
+    }
+}
+
+async fn handle_write_action(args: &Value, uc: &InputUseCases) -> Result<Value, DomainError> {
+    let op = req_str(args, "op")?;
+    match op.as_str() {
+        "create" => {
+            let name = str_opt(args, "name");
+            let title = str_opt(args, "title");
+            let brief = str_opt(args, "brief");
+            let tags = tags_opt(args)?;
+            let ttl_minutes = req_u64(args, "ttl_minutes")?;
+            let pack = uc
+                .create_with_tags_ttl(name, title, brief, tags, ttl_minutes)
+                .await?;
+            tool_success("write", serde_json::to_value(pack)?)
+        }
+        "upsert_section" => {
+            reject_legacy_alias(args, "title", "section_title")?;
+            reject_legacy_alias(args, "description", "section_description")?;
+            let ident = req_identifier(args)?;
+            let expected_revision = req_u64(args, "expected_revision")?;
+            let section_key = req_str(args, "section_key")?;
+            let title = req_str(args, "section_title")?;
+            let description = str_opt(args, "section_description");
+            let order = usize_opt(args, "section_order")?;
+            let pack = uc
+                .upsert_section_checked(
+                    &ident,
+                    &section_key,
+                    title,
+                    description,
+                    order,
+                    expected_revision,
+                )
+                .await?;
+            tool_success("write", serde_json::to_value(pack)?)
+        }
+        "delete_section" => {
+            let ident = req_identifier(args)?;
+            let expected_revision = req_u64(args, "expected_revision")?;
+            let section_key = req_str(args, "section_key")?;
+            let pack = uc
+                .delete_section_checked(&ident, &section_key, expected_revision)
+                .await?;
+            tool_success("write", serde_json::to_value(pack)?)
+        }
+        "upsert_ref" => {
+            reject_legacy_alias(args, "title", "ref_title")?;
+            reject_legacy_alias(args, "why", "ref_why")?;
+            let ident = req_identifier(args)?;
+            let expected_revision = req_u64(args, "expected_revision")?;
+            let req = UpsertRefRequest {
+                section_key: req_str(args, "section_key")?,
+                ref_key: req_str(args, "ref_key")?,
+                path: req_str(args, "path")?,
+                line_start: req_usize(args, "line_start")?,
+                line_end: req_usize(args, "line_end")?,
+                title: str_opt(args, "ref_title"),
+                why: str_opt(args, "ref_why"),
+                group: str_opt(args, "group"),
+            };
+            let pack = uc
+                .upsert_ref_checked(&ident, req, expected_revision)
+                .await?;
+            tool_success("write", serde_json::to_value(pack)?)
+        }
+        "delete_ref" => {
+            let ident = req_identifier(args)?;
+            let expected_revision = req_u64(args, "expected_revision")?;
+            let section_key = req_str(args, "section_key")?;
+            let ref_key = req_str(args, "ref_key")?;
+            let pack = uc
+                .delete_ref_checked(&ident, &section_key, &ref_key, expected_revision)
+                .await?;
+            tool_success("write", serde_json::to_value(pack)?)
+        }
+        "upsert_diagram" => {
+            reject_legacy_alias(args, "why", "diagram_why")?;
+            let ident = req_identifier(args)?;
+            let expected_revision = req_u64(args, "expected_revision")?;
+            let request = UpsertDiagramRequest {
+                section_key: req_str(args, "section_key")?,
+                diagram_key: req_str(args, "diagram_key")?,
+                title: req_str(args, "title")?,
+                mermaid: req_str(args, "mermaid")?,
+                why: str_opt(args, "diagram_why"),
+            };
+            let pack = uc
+                .upsert_diagram_checked(&ident, request, expected_revision)
+                .await?;
+            tool_success("write", serde_json::to_value(pack)?)
+        }
+        "set_meta" => {
+            let ident = req_identifier(args)?;
+            let expected_revision = req_u64(args, "expected_revision")?;
+            let title = str_opt(args, "title");
+            let brief = str_opt(args, "brief");
+            let tags = tags_opt(args)?;
+            let pack = uc
+                .set_meta_checked(&ident, title, brief, tags, expected_revision)
+                .await?;
+            tool_success("write", serde_json::to_value(pack)?)
+        }
+        "set_status" => {
+            let ident = req_identifier(args)?;
+            let expected_revision = req_u64(args, "expected_revision")?;
+            let status = req_status(args, "status")?;
+            let pack = uc
+                .set_status_checked(&ident, status, expected_revision)
+                .await?;
+            tool_success("write", serde_json::to_value(pack)?)
+        }
         _ => Err(DomainError::InvalidData(format!(
-            "unknown input action '{}'",
-            action
+            "unknown write op '{}'; allowed ops: create, upsert_section, delete_section, upsert_ref, delete_ref, upsert_diagram, set_meta, set_status",
+            op
         ))),
+    }
+}
+
+fn unsupported_input_action(action: &str) -> DomainError {
+    let hint = match action {
+        "create" | "upsert_section" | "delete_section" | "upsert_ref" | "delete_ref"
+        | "upsert_diagram" | "set_meta" | "set_status" => {
+            Some(format!("use action='write' with op='{}'", action))
+        }
+        "touch_ttl" => Some("use action='ttl'".to_string()),
+        "delete_pack" => Some("use action='delete'".to_string()),
+        _ => None,
+    };
+
+    if let Some(hint) = hint {
+        DomainError::InvalidData(format!(
+            "input action '{}' is not supported in v3; {}",
+            action, hint
+        ))
+    } else {
+        DomainError::InvalidData(format!(
+            "unknown input action '{}'; allowed actions: list, get, write, ttl, delete",
+            action
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary
S1 contract cutover for v3 action surface (issue #71):
- `input` actions cut to `list|get|write|ttl|delete`
- `output` actions cut to `list|read`
- legacy top-level actions are fail-closed with explicit `invalid_data` guidance
- schema + stdio routing updated to v3 action surface
- e2e contract-dispatch coverage added/updated

Refs #71
Parent: #70

## Scope control
Touch only:
- `src/adapters/mcp_stdio/schema.rs`
- `src/adapters/mcp_stdio/tool_input.rs`
- `src/adapters/mcp_stdio/tool_output.rs`
- `tests/e2e.rs`

NoTouch respected:
- no `storage_json.rs` algorithmic changes
- no finalize validation internals changes
- no output rendering internals changes beyond v3 routing dispatch

## Acceptance mapping
1. tools/list schema exposes only v3 action enums ✅
2. legacy actions return explicit invalid_data ✅
3. entrypoints compile/run with v3 handlers ✅
4. e2e verifies dispatch contract ✅

## Required gates (PASS)
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `scripts/check_coverage_baseline.sh`
- `cargo audit`
