### PR TITLE
S2: atomic input.write snapshot + validate_only precheck

### DIFF
--- a/src/app/input_usecases.rs
+++ b/src/app/input_usecases.rs
@@ -10,12 +10,13 @@ use crate::{
             revision_conflict_guidance, DomainError, FinalizeRefIssue, Result,
             REVISION_CONFLICT_CHANGED_KEYS_LIMIT,
         },
-        models::{Pack, RefSpec},
+        models::{CodeRef, Diagram, Pack, RefSpec, Section},
         types::{
             DiagramKey, LineRange, PackId, PackName, RefKey, RelativePath, SectionKey, Status,
         },
     },
 };
+use std::collections::HashSet;
 
 pub struct InputUseCases {
     repo: Arc<dyn PackRepositoryPort>,
@@ -36,6 +37,48 @@ pub struct UpsertRefRequest {
 pub struct UpsertDiagramRequest {
     pub section_key: String,
     pub diagram_key: String,
+    pub title: String,
+    pub mermaid: String,
+    pub why: Option<String>,
+}
+
+pub struct WriteSnapshotRequest {
+    pub identifier: Option<String>,
+    pub expected_revision: Option<u64>,
+    pub validate_only: bool,
+    pub snapshot: SnapshotDocument,
+}
+
+pub struct SnapshotDocument {
+    pub name: Option<String>,
+    pub title: Option<String>,
+    pub brief: Option<String>,
+    pub tags: Vec<String>,
+    pub ttl_minutes: Option<u64>,
+    pub status: Status,
+    pub sections: Vec<SnapshotSection>,
+}
+
+pub struct SnapshotSection {
+    pub key: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub refs: Vec<SnapshotRef>,
+    pub diagrams: Vec<SnapshotDiagram>,
+}
+
+pub struct SnapshotRef {
+    pub key: String,
+    pub path: String,
+    pub line_start: usize,
+    pub line_end: usize,
+    pub title: Option<String>,
+    pub why: Option<String>,
+    pub group: Option<String>,
+}
+
+pub struct SnapshotDiagram {
+    pub key: String,
     pub title: String,
     pub mermaid: String,
     pub why: Option<String>,
@@ -129,6 +172,126 @@ impl InputUseCases {
         })
     }
 
+    async fn validate_finalize_state_if_needed(&self, pack: &Pack) -> Result<()> {
+        if pack.status == Status::Finalized {
+            pack.validate_finalize_gate()?;
+            self.validate_refs_resolvable_before_finalize(pack).await?;
+        }
+        Ok(())
+    }
+
+    fn snapshot_sections(snapshot: &[SnapshotSection]) -> Result<Vec<Section>> {
+        let mut sections = Vec::with_capacity(snapshot.len());
+        let mut seen_sections = HashSet::new();
+
+        for section in snapshot {
+            let key = SectionKey::new(&section.key)?;
+            let section_key = key.as_str().to_string();
+            if !seen_sections.insert(section_key.clone()) {
+                return Err(DomainError::InvalidData(format!(
+                    "duplicate section_key '{}' in snapshot",
+                    section_key
+                )));
+            }
+
+            let mut refs = Vec::with_capacity(section.refs.len());
+            let mut seen_refs = HashSet::new();
+            for code_ref in &section.refs {
+                let ref_key = RefKey::new(&code_ref.key)?;
+                let ref_key_str = ref_key.as_str().to_string();
+                if !seen_refs.insert(ref_key_str.clone()) {
+                    return Err(DomainError::InvalidData(format!(
+                        "duplicate ref_key '{}' in section '{}'",
+                        ref_key_str, section_key
+                    )));
+                }
+                refs.push(CodeRef {
+                    key: ref_key,
+                    path: RelativePath::new(&code_ref.path)?,
+                    lines: LineRange::new(code_ref.line_start, code_ref.line_end)?,
+                    title: code_ref.title.clone(),
+                    why: code_ref.why.clone(),
+                    group: code_ref.group.clone(),
+                });
+            }
+
+            let mut diagrams = Vec::with_capacity(section.diagrams.len());
+            let mut seen_diagrams = HashSet::new();
+            for diagram in &section.diagrams {
+                let diagram_key = DiagramKey::new(&diagram.key)?;
+                let diagram_key_str = diagram_key.as_str().to_string();
+                if !seen_diagrams.insert(diagram_key_str.clone()) {
+                    return Err(DomainError::InvalidData(format!(
+                        "duplicate diagram_key '{}' in section '{}'",
+                        diagram_key_str, section_key
+                    )));
+                }
+                diagrams.push(Diagram {
+                    key: diagram_key,
+                    title: diagram.title.clone(),
+                    mermaid: diagram.mermaid.clone(),
+                    why: diagram.why.clone(),
+                });
+            }
+
+            sections.push(Section {
+                key,
+                title: section.title.clone(),
+                description: section.description.clone(),
+                refs,
+                diagrams,
+            });
+        }
+
+        Ok(sections)
+    }
+
+    fn build_create_snapshot(snapshot: SnapshotDocument) -> Result<Pack> {
+        let pack_name = snapshot.name.as_deref().map(PackName::new).transpose()?;
+        let mut pack = Pack::new(PackId::new(), pack_name);
+        if let Some(ttl_minutes) = snapshot.ttl_minutes {
+            pack.set_ttl_on_create(ttl_minutes, pack.created_at)?;
+        }
+        pack.title = snapshot.title;
+        pack.brief = snapshot.brief;
+        pack.tags = snapshot.tags;
+        pack.status = snapshot.status;
+        pack.sections = Self::snapshot_sections(&snapshot.sections)?;
+        Ok(pack)
+    }
+
+    fn build_update_snapshot(current: &Pack, snapshot: SnapshotDocument) -> Result<Pack> {
+        if let Some(snapshot_name) = snapshot.name {
+            let parsed = PackName::new(&snapshot_name)?;
+            if current.name.as_ref() != Some(&parsed) {
+                return Err(DomainError::InvalidData(
+                    "name is immutable for existing packs".into(),
+                ));
+            }
+        }
+
+        let now = chrono::Utc::now();
+        let mut pack = Pack {
+            schema_version: current.schema_version,
+            id: current.id.clone(),
+            name: current.name.clone(),
+            title: snapshot.title,
+            brief: snapshot.brief,
+            status: snapshot.status,
+            tags: snapshot.tags,
+            sections: Self::snapshot_sections(&snapshot.sections)?,
+            revision: current.revision.saturating_add(1),
+            created_at: current.created_at,
+            updated_at: now,
+            expires_at: current.expires_at,
+        };
+
+        if let Some(ttl_minutes) = snapshot.ttl_minutes {
+            pack.expires_at = Pack::ttl_deadline_from_now(ttl_minutes, now)?;
+        }
+        Ok(pack)
+    }
+
     // ── queries ───────────────────────────────────────────────────────────────
 
     pub async fn list(
@@ -204,6 +367,51 @@ impl InputUseCases {
         Err(DomainError::Conflict(
             "failed to allocate unique pack id".into(),
         ))
+    }
+
+    pub async fn write_snapshot(&self, request: WriteSnapshotRequest) -> Result<Pack> {
+        match request.identifier {
+            Some(identifier) => {
+                let expected_revision = request.expected_revision.ok_or_else(|| {
+                    DomainError::InvalidData(
+                        "expected_revision is required when updating by identifier".into(),
+                    )
+                })?;
+                let current = self.resolve(&identifier).await?;
+                if current.revision != expected_revision {
+                    return Err(DomainError::RevisionConflictDetailed {
+                        expected_revision,
+                        current_revision: current.revision,
+                        last_updated_at: current.updated_at.to_rfc3339(),
+                        changed_section_keys: conflict_changed_section_keys(&current),
+                        guidance: revision_conflict_guidance(current.revision),
+                    });
+                }
+
+                let pack = Self::build_update_snapshot(&current, request.snapshot)?;
+                self.validate_finalize_state_if_needed(&pack).await?;
+                if !request.validate_only {
+                    self.repo
+                        .save_with_expected_revision(&pack, expected_revision)
+                        .await?;
+                }
+                Ok(pack)
+            }
+            None => {
+                if request.expected_revision.is_some() {
+                    return Err(DomainError::InvalidData(
+                        "expected_revision is only valid when identifier is set".into(),
+                    ));
+                }
+
+                let pack = Self::build_create_snapshot(request.snapshot)?;
+                self.validate_finalize_state_if_needed(&pack).await?;
+                if !request.validate_only {
+                    self.repo.create_new(&pack).await?;
+                }
+                Ok(pack)
+            }
+        }
     }
 
     pub async fn set_status_checked(

--- a/src/domain/models.rs
+++ b/src/domain/models.rs
@@ -209,6 +209,10 @@ impl Pack {
         Ok(())
     }
 
+    pub fn ttl_deadline_from_now(minutes: u64, now: DateTime<Utc>) -> Result<DateTime<Utc>> {
+        Ok(now + ttl_duration(minutes)?)
+    }
+
     pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
         self.expires_at <= now
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,7 +6,10 @@ use chrono::{Duration, Utc};
 use mcp_context_pack::{
     adapters::{code_excerpt_fs::CodeExcerptFsAdapter, storage_json::JsonStorageAdapter},
     app::{
-        input_usecases::{InputUseCases, TouchTtlMode, UpsertRefRequest},
+        input_usecases::{
+            InputUseCases, SnapshotDocument, SnapshotRef, SnapshotSection, TouchTtlMode,
+            UpsertRefRequest, WriteSnapshotRequest,
+        },
         output_usecases::{OutputGetRequest, OutputMode, OutputUseCases},
         ports::FreshnessState,
     },
@@ -59,6 +62,33 @@ fn write_pack_file(storage_dir: &std::path::Path, pack: &Pack) {
         payload,
     )
     .unwrap();
+}
+
+fn snapshot_section(
+    key: &str,
+    title: &str,
+    description: Option<&str>,
+    refs: Vec<SnapshotRef>,
+) -> SnapshotSection {
+    SnapshotSection {
+        key: key.to_string(),
+        title: title.to_string(),
+        description: description.map(str::to_string),
+        refs,
+        diagrams: Vec::new(),
+    }
+}
+
+fn snapshot_ref(key: &str, path: &str, line_start: usize, line_end: usize) -> SnapshotRef {
+    SnapshotRef {
+        key: key.to_string(),
+        path: path.to_string(),
+        line_start,
+        line_end,
+        title: None,
+        why: None,
+        group: None,
+    }
 }
 
 #[tokio::test]
@@ -416,6 +446,213 @@ async fn test_draft_workflow_remains_flexible_before_finalize() {
             .any(|section| section.key.as_str() == "notes"),
         "draft mutations should remain allowed without finalize checklist sections"
     );
+}
+
+#[tokio::test]
+async fn test_write_snapshot_create_and_update_full_replace() {
+    let tmp = tempdir().unwrap();
+    let storage_dir = tmp.path().join("packs");
+    let source_root = tmp.path().join("src");
+    std::fs::create_dir_all(&source_root).unwrap();
+    std::fs::write(source_root.join("sample.rs"), "line1\nline2\nline3\n").unwrap();
+
+    let (input_uc, _) = build_services(storage_dir, tmp.path().to_path_buf());
+
+    let created = input_uc
+        .write_snapshot(WriteSnapshotRequest {
+            identifier: None,
+            expected_revision: None,
+            validate_only: false,
+            snapshot: SnapshotDocument {
+                name: Some("snapshot-flow-pack".into()),
+                title: Some("Snapshot flow".into()),
+                brief: Some("initial".into()),
+                tags: vec!["s2".into()],
+                ttl_minutes: Some(30),
+                status: Status::Draft,
+                sections: vec![snapshot_section(
+                    "notes",
+                    "Notes",
+                    Some("draft-only section"),
+                    vec![],
+                )],
+            },
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(created.status, Status::Draft);
+    assert_eq!(created.sections.len(), 1);
+    assert_eq!(created.sections[0].key.as_str(), "notes");
+
+    let pack_id = created.id.as_str().to_string();
+    let updated = input_uc
+        .write_snapshot(WriteSnapshotRequest {
+            identifier: Some(pack_id.clone()),
+            expected_revision: Some(created.revision),
+            validate_only: false,
+            snapshot: SnapshotDocument {
+                name: Some("snapshot-flow-pack".into()),
+                title: Some("Snapshot updated".into()),
+                brief: None,
+                tags: vec!["released".into()],
+                ttl_minutes: Some(45),
+                status: Status::Draft,
+                sections: vec![snapshot_section(
+                    "scope",
+                    "Scope",
+                    Some("full replace should drop previous sections"),
+                    vec![],
+                )],
+            },
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(updated.revision, created.revision + 1);
+    assert_eq!(updated.sections.len(), 1);
+    assert_eq!(updated.sections[0].key.as_str(), "scope");
+    assert_eq!(updated.tags, vec!["released"]);
+
+    let reread = input_uc.get(&pack_id).await.unwrap();
+    assert_eq!(reread.sections.len(), 1);
+    assert_eq!(reread.sections[0].key.as_str(), "scope");
+    assert!(reread
+        .sections
+        .iter()
+        .all(|section| section.key.as_str() != "notes"));
+}
+
+#[tokio::test]
+async fn test_write_snapshot_validate_only_finalize_precheck_is_non_persistent() {
+    let tmp = tempdir().unwrap();
+    let storage_dir = tmp.path().join("packs");
+    let source_root = tmp.path().join("src");
+    std::fs::create_dir_all(&source_root).unwrap();
+    std::fs::write(source_root.join("short.rs"), "line1\nline2\n").unwrap();
+
+    let (input_uc, _) = build_services(storage_dir, tmp.path().to_path_buf());
+
+    let created = input_uc
+        .write_snapshot(WriteSnapshotRequest {
+            identifier: None,
+            expected_revision: None,
+            validate_only: false,
+            snapshot: SnapshotDocument {
+                name: Some("validate-only-pack".into()),
+                title: None,
+                brief: None,
+                tags: vec![],
+                ttl_minutes: Some(30),
+                status: Status::Draft,
+                sections: vec![snapshot_section(
+                    "notes",
+                    "Notes",
+                    Some("seed draft"),
+                    vec![],
+                )],
+            },
+        })
+        .await
+        .unwrap();
+
+    let before_revision = created.revision;
+    let pack_id = created.id.as_str().to_string();
+
+    let err = input_uc
+        .write_snapshot(WriteSnapshotRequest {
+            identifier: Some(pack_id.clone()),
+            expected_revision: Some(before_revision),
+            validate_only: true,
+            snapshot: SnapshotDocument {
+                name: Some("validate-only-pack".into()),
+                title: Some("Finalize attempt".into()),
+                brief: None,
+                tags: vec!["precheck".into()],
+                ttl_minutes: None,
+                status: Status::Finalized,
+                sections: vec![
+                    snapshot_section("scope", "Scope", Some("scope text"), vec![]),
+                    snapshot_section(
+                        "findings",
+                        "Findings",
+                        Some("finding text"),
+                        vec![snapshot_ref("ref-one", "src/short.rs", 10, 10)],
+                    ),
+                    snapshot_section("qa", "QA", Some("verdict: fail"), vec![]),
+                ],
+            },
+        })
+        .await
+        .expect_err("validate_only finalize precheck must return structured diagnostics");
+
+    match err {
+        DomainError::FinalizeValidation {
+            missing_sections,
+            missing_fields,
+            invalid_refs,
+            ..
+        } => {
+            assert!(missing_sections.is_empty());
+            assert!(missing_fields.is_empty());
+            assert_eq!(invalid_refs.len(), 1);
+            assert_eq!(invalid_refs[0].section_key, "findings");
+            assert_eq!(invalid_refs[0].ref_key, "ref-one");
+        }
+        other => panic!("expected FinalizeValidation, got {other:?}"),
+    }
+
+    let after = input_uc.get(&pack_id).await.unwrap();
+    assert_eq!(
+        after.revision, before_revision,
+        "validate_only=true must not persist or mutate revision"
+    );
+    assert_eq!(after.status, Status::Draft);
+    assert_eq!(after.sections.len(), 1);
+    assert_eq!(after.sections[0].key.as_str(), "notes");
+}
+
+#[tokio::test]
+async fn test_write_snapshot_finalize_minimal_success() {
+    let tmp = tempdir().unwrap();
+    let storage_dir = tmp.path().join("packs");
+    let source_root = tmp.path().join("src");
+    std::fs::create_dir_all(&source_root).unwrap();
+    std::fs::write(source_root.join("sample.rs"), "line1\nline2\nline3\n").unwrap();
+
+    let (input_uc, _) = build_services(storage_dir, tmp.path().to_path_buf());
+
+    let finalized = input_uc
+        .write_snapshot(WriteSnapshotRequest {
+            identifier: None,
+            expected_revision: None,
+            validate_only: false,
+            snapshot: SnapshotDocument {
+                name: Some("minimal-finalize-pack".into()),
+                title: Some("Minimal finalize".into()),
+                brief: None,
+                tags: vec![],
+                ttl_minutes: Some(30),
+                status: Status::Finalized,
+                sections: vec![
+                    snapshot_section("scope", "Scope", Some("scope text"), vec![]),
+                    snapshot_section(
+                        "findings",
+                        "Findings",
+                        Some("finding text"),
+                        vec![snapshot_ref("ref-one", "src/sample.rs", 1, 2)],
+                    ),
+                    snapshot_section("qa", "QA", Some("verdict: pass"), vec![]),
+                ],
+            },
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(finalized.status, Status::Finalized);
+    let reread = input_uc.get("minimal-finalize-pack").await.unwrap();
+    assert_eq!(reread.status, Status::Finalized);
+    assert_eq!(reread.sections.len(), 3);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add snapshot-based `input.write` path for atomic full-replace create/update
- add `validate_only=true` finalize precheck that runs full finalize validation (including stale refs) without persistence
- keep finalize fail-closed diagnostics structured and draft flow flexible
- add integration + e2e coverage for snapshot create/update, validate_only non-persistence, and finalized success

## Scope
- Implements issue #72 only (S2).
- No changes to output profiles/paging or purge scheduling.

## Required gates
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features`
- [x] `scripts/check_coverage_baseline.sh`
- [x] `cargo audit`

Refs #72
