### PR TITLE
S3: output.read profiles + page_token paging

### DIFF
--- a/src/adapters/mcp_stdio/schema.rs
+++ b/src/adapters/mcp_stdio/schema.rs
@@ -77,21 +77,21 @@ pub(super) fn tools_schema() -> Value {
                         "status": {
                             "type": "string",
                             "enum": ["draft", "finalized"],
-                            "description": "Optional status filter (for list and get)"
+                            "description": "Optional status filter (for list and read)"
                         },
                         "freshness": {
                             "type": "string",
                             "enum": ["fresh", "expiring_soon", "expired"],
                             "description": "Optional freshness filter for list."
                         },
-                        "mode": {
+                        "profile": {
                             "type": "string",
-                            "enum": ["full", "compact"],
-                            "description": "Render mode for output get (default: compact handoff page; use full for complete snippets)"
+                            "enum": ["orchestrator", "reviewer", "executor"],
+                            "description": "Read profile defaults: orchestrator (compact bounded), reviewer (full evidence), executor (actionable compact)."
                         },
                         "query": { "type": "string", "description": "Optional text search for list" },
-                        "cursor": { "type": "string", "description": "Opaque cursor returned by output get paging metadata" },
-                        "match": { "type": "string", "description": "Regex filter applied to output get chunks" },
+                        "page_token": { "type": "string", "description": "Opaque page token returned by output read paging metadata." },
+                        "contains": { "type": "string", "description": "Optional substring filter applied to rendered chunks." },
                         "limit": { "type": "integer" },
                         "offset": { "type": "integer" }
                     }

--- a/tests/unit_output.rs
+++ b/tests/unit_output.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, sync::Arc, sync::Mutex};
 
 use mcp_context_pack::{
     app::{
-        output_usecases::OutputUseCases,
+        output_usecases::{OutputProfile, OutputReadRequest, OutputUseCases},
         ports::{CodeExcerptPort, ListFilter, PackRepositoryPort, Snippet},
     },
     domain::{
@@ -133,7 +133,16 @@ async fn test_render_legend_contains_id_and_status() {
     let pack = simple_pack();
     let id_str = pack.id.as_str().to_string();
     let uc = make_output(vec![pack], FakeExcerptPort::stale());
-    let rendered = uc.get_rendered(&id_str, None).await.unwrap();
+    let rendered = uc
+        .get_rendered_with_request(
+            &id_str,
+            OutputReadRequest {
+                profile: Some(OutputProfile::Reviewer),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
     assert!(rendered.contains("[LEGEND]"), "missing [LEGEND]");
     assert!(rendered.contains(&id_str), "id missing from legend");
     assert!(rendered.contains("draft"), "status missing from legend");
@@ -146,7 +155,16 @@ async fn test_render_with_name_and_brief() {
     pack.brief = Some("brief description".to_string());
     let id_str = pack.id.as_str().to_string();
     let uc = make_output(vec![pack], FakeExcerptPort::stale());
-    let rendered = uc.get_rendered(&id_str, None).await.unwrap();
+    let rendered = uc
+        .get_rendered_with_request(
+            &id_str,
+            OutputReadRequest {
+                profile: Some(OutputProfile::Reviewer),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
     assert!(rendered.contains("my-feature"), "name missing");
     assert!(rendered.contains("brief description"), "brief missing");
 }
@@ -158,7 +176,16 @@ async fn test_render_with_tags() {
     pack.tags = vec!["rust".to_string(), "backend".to_string()];
     let id_str = pack.id.as_str().to_string();
     let uc = make_output(vec![pack], FakeExcerptPort::stale());
-    let rendered = uc.get_rendered(&id_str, None).await.unwrap();
+    let rendered = uc
+        .get_rendered_with_request(
+            &id_str,
+            OutputReadRequest {
+                profile: Some(OutputProfile::Reviewer),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
     assert!(rendered.contains("rust"), "tag 'rust' missing");
     assert!(rendered.contains("backend"), "tag 'backend' missing");
 }
@@ -197,7 +224,16 @@ async fn test_render_with_section_and_ref() {
         vec![pack],
         FakeExcerptPort::with(vec![("src/lib.rs", "   1: fn main() {}")]),
     );
-    let rendered = uc.get_rendered(&id_str, None).await.unwrap();
+    let rendered = uc
+        .get_rendered_with_request(
+            &id_str,
+            OutputReadRequest {
+                profile: Some(OutputProfile::Reviewer),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
     assert!(rendered.contains("[CONTENT]"), "missing [CONTENT]");
     assert!(rendered.contains("Main Section"), "section title missing");
     assert!(rendered.contains("fn main()"), "code excerpt missing");
@@ -229,7 +265,16 @@ async fn test_render_stale_ref_shown_as_warning() {
     let id_str = pack.id.as_str().to_string();
     // FakeExcerptPort::stale() returns StaleRef for every path
     let uc = make_output(vec![pack], FakeExcerptPort::stale());
-    let rendered = uc.get_rendered(&id_str, None).await.unwrap();
+    let rendered = uc
+        .get_rendered_with_request(
+            &id_str,
+            OutputReadRequest {
+                profile: Some(OutputProfile::Reviewer),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
     assert!(
         rendered.contains("> stale ref:"),
         "expected stale ref warning, got:\n{rendered}"
@@ -259,7 +304,16 @@ async fn test_render_with_diagram_block() {
 
     let id_str = pack.id.as_str().to_string();
     let uc = make_output(vec![pack], FakeExcerptPort::stale());
-    let rendered = uc.get_rendered(&id_str, None).await.unwrap();
+    let rendered = uc
+        .get_rendered_with_request(
+            &id_str,
+            OutputReadRequest {
+                profile: Some(OutputProfile::Reviewer),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
     assert!(
         rendered.contains("```mermaid"),
         "expected mermaid block, got:\n{rendered}"
@@ -350,7 +404,16 @@ async fn test_lang_detection_rust_extension() {
         vec![pack],
         FakeExcerptPort::with(vec![("src/main.rs", "   1: fn main() {}")]),
     );
-    let rendered = uc.get_rendered(&id_str, None).await.unwrap();
+    let rendered = uc
+        .get_rendered_with_request(
+            &id_str,
+            OutputReadRequest {
+                profile: Some(OutputProfile::Reviewer),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
     assert!(
         rendered.contains("```rust"),
         "expected ```rust language tag, got:\n{rendered}"
@@ -383,7 +446,16 @@ async fn test_lang_detection_unknown_extension() {
         vec![pack],
         FakeExcerptPort::with(vec![("data/file.xyz", "   1: some data")]),
     );
-    let rendered = uc.get_rendered(&id_str, None).await.unwrap();
+    let rendered = uc
+        .get_rendered_with_request(
+            &id_str,
+            OutputReadRequest {
+                profile: Some(OutputProfile::Reviewer),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
     // Should contain ``` but NOT ```rust or any other lang tag
     assert!(rendered.contains("```\n"), "expected empty lang tag ```\\n");
     assert!(


### PR DESCRIPTION
## Summary
- Implements issue #73.
- Replaced `output.get` with `output.read` on the MCP surface.
- Added read profiles: `orchestrator` (default bounded compact), `reviewer` (full evidence), and `executor` (actionable compact with higher default limit).
- Replaced continuation state with deterministic `page_token` and strict continuation validation.
- Replaced regex-style `match` filtering with deterministic `contains` substring filtering.
- Added explicit rejection for legacy query fields in `output` reads (`mode`, `cursor`, `match`) with `invalid_data` errors.

## Acceptance evidence
- Added/updated unit + integration + E2E coverage for profile defaults, paging behavior, contains filtering, and legacy-field rejection.

## Required gates
- `cargo fmt --check` ✅ PASS
- `cargo clippy --all-targets --all-features -- -D warnings` ✅ PASS
- `cargo test --all-targets --all-features` ✅ PASS
- `scripts/check_coverage_baseline.sh` ✅ PASS
- `cargo audit` ✅ PASS

Refs #73