### PR TITLE
S5: v3 error/diagnostics normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,23 @@ CONTEXT_PACK_EXPIRED_GRACE_SECONDS = "900"
 - `contains` performs deterministic case-insensitive substring matching over rendered chunk text.
 - `output` is always markdown (`format` is rejected).
 
+### Error contract (v3)
+
+For v3 validation failures (`code=invalid_data`), payloads are normalized and stable:
+
+- `kind`: always `validation`
+- `code`: always `invalid_data`
+- `details`: deterministic machine-readable guidance, including:
+  - requested/legacy fields (`requested_action`, `requested_field`, `supported_field`, etc.),
+  - allowed replacement sets (`allowed_actions`, `allowed_ops`),
+  - and required inputs (`required_fields`, `mutually_interchangeable`).
+- `message`: concise human-readable summary that mirrors the same intent as `details`.
+
+Examples:
+
+- `input`/`output` legacy action or field usage returns actionable guidance (`action='write'`, `use action='read'`, `unsupported_field` + `supported_field`).
+- `input delete` and `output read` report required identifier keys explicitly (`id`/`name`).
+
 ### Finalize checklist (fail-closed)
 
 Before setting `status=finalized`, ensure:

--- a/src/adapters/mcp_stdio/error_contract.rs
+++ b/src/adapters/mcp_stdio/error_contract.rs
@@ -7,7 +7,18 @@ use crate::domain::errors::DomainError;
 pub(super) fn domain_error_response(id: Value, err: &DomainError) -> RpcEnvelope {
     let (kind, code, details) = match err {
         DomainError::InvalidData(_) => ("validation", "invalid_data", Value::Null),
-        DomainError::TtlRequired(_) => ("validation", "ttl_required", Value::Null),
+        DomainError::DetailedInvalidData {
+            details,
+            message: _,
+        } => ("validation", "invalid_data", details.clone()),
+        DomainError::TtlRequired(_) => (
+            "validation",
+            "ttl_required",
+            json!({
+                "required_fields": ["ttl_minutes", "extend_minutes"],
+                "required_mode_hint": "exactly_one_of",
+            }),
+        ),
         DomainError::NotFound(_) => ("not_found", "not_found", Value::Null),
         DomainError::Conflict(_) => ("conflict", "conflict", Value::Null),
         DomainError::Ambiguous { candidates, .. } => (

--- a/src/domain/errors.rs
+++ b/src/domain/errors.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use thiserror::Error;
 
 pub const REVISION_CONFLICT_CHANGED_KEYS_LIMIT: usize = 12;
@@ -32,6 +33,9 @@ pub fn revision_conflict_guidance(current_revision: u64) -> String {
 pub enum DomainError {
     #[error("invalid data: {0}")]
     InvalidData(String),
+
+    #[error("{message}")]
+    DetailedInvalidData { message: String, details: Value },
 
     #[error("ttl required: {0}")]
     TtlRequired(String),


### PR DESCRIPTION
Closes #75. 

Implements deterministic v3 validation error contracts + preserves rich conflict/finalize diagnostics.

Acceptance evidence:
- deterministic  payloads for v3 negative paths in input/output
- required fields and stable guidance for legacy actions/fields
- conflict/finalize diagnostics unchanged
- negative-path tests in v2/e2e coverage
