### PR TITLE
Issue #83: enforce document-only input.write snapshot contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,11 @@ CONTEXT_PACK_EXPIRED_GRACE_SECONDS = "900"
 ## Tool contract (short)
 
 - Pack id format: `pk_[a-z2-7]{8}`.
-- `input` actions: `list`, `create`, `get`, `upsert_section`, `delete_section`, `upsert_ref`, `delete_ref`, `upsert_diagram`, `set_meta`, `set_status`, `touch_ttl`, `delete_pack`.
-- All mutating actions except `create` and `delete_pack` require `expected_revision`.
-- `create` requires `ttl_minutes`.
-- `touch_ttl` accepts exactly one: `ttl_minutes` or `extend_minutes`.
+- `input` actions: `list`, `get`, `write`, `ttl`, `delete`.
+- `input write` is **document-only** full-replace snapshot (`document` object); legacy `op` and granular mutation fields are rejected with guidance.
+- Update writes require `id|name` + `expected_revision`; create writes omit both and allocate a new pack id.
+- `validate_only=true` runs the same snapshot/finalize validations but does not persist changes.
+- `ttl` accepts exactly one: `ttl_minutes` or `extend_minutes`.
 - `output` actions stay `list|read` (no extra tool/action sprawl).
 - `input list` and `output list` accept optional `freshness` filter:
   - `fresh`
@@ -611,10 +612,11 @@ CONTEXT_PACK_MAX_SOURCE_BYTES = "2097152"
 ## Краткий контракт инструментов
 
 - Формат id: `pk_[a-z2-7]{8}`.
-- `input` actions: `list`, `create`, `get`, `upsert_section`, `delete_section`, `upsert_ref`, `delete_ref`, `upsert_diagram`, `set_meta`, `set_status`, `touch_ttl`, `delete_pack`.
-- Все мутации, кроме `create` и `delete_pack`, требуют `expected_revision`.
-- `create` требует `ttl_minutes`.
-- `touch_ttl` принимает строго одно: `ttl_minutes` или `extend_minutes`.
+- `input` actions: `list`, `get`, `write`, `ttl`, `delete`.
+- `input write` работает только через **full-replace `document`**; legacy `op` и granular-поля мутаций отклоняются с подсказкой миграции.
+- Update-write требует `id|name` + `expected_revision`; create-write выполняется без них и создаёт новый pack id.
+- `validate_only=true` запускает те же проверки snapshot/finalize, но без persistence.
+- `ttl` принимает строго одно: `ttl_minutes` или `extend_minutes`.
 - `output` остаётся с actions только `list|read` (без разрастания API).
 - `input list` и `output list` принимают опциональный фильтр `freshness`:
   - `fresh`

--- a/src/adapters/mcp_stdio/mod.rs
+++ b/src/adapters/mcp_stdio/mod.rs
@@ -302,29 +302,12 @@ pub(super) fn req_identifier(args: &Value) -> Result<String, DomainError> {
     })
 }
 
-pub(super) fn req_str(args: &Value, key: &str) -> Result<String, DomainError> {
-    args.get(key)
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
-        .ok_or_else(|| DomainError::InvalidData(format!("'{}' is required", key)))
-}
-
 pub(super) fn str_opt(args: &Value, key: &str) -> Option<String> {
     args.get(key)
         .and_then(|v| v.as_str())
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(str::to_string)
-}
-
-pub(super) fn req_usize(args: &Value, key: &str) -> Result<usize, DomainError> {
-    let raw = args
-        .get(key)
-        .and_then(|v| v.as_u64())
-        .ok_or_else(|| DomainError::InvalidData(format!("'{}' is required", key)))?;
-    usize::try_from(raw).map_err(|_| DomainError::InvalidData(format!("'{}' is out of range", key)))
 }
 
 pub(super) fn usize_opt(args: &Value, key: &str) -> Result<Option<usize>, DomainError> {
@@ -352,11 +335,6 @@ pub(super) fn u64_opt(args: &Value, key: &str) -> Result<Option<u64>, DomainErro
         .ok_or_else(|| DomainError::InvalidData(format!("'{}' must be an integer", key)))
 }
 
-pub(super) fn req_status(args: &Value, key: &str) -> Result<Status, DomainError> {
-    let raw = req_str(args, key)?;
-    raw.parse::<Status>()
-}
-
 pub(super) fn status_opt(args: &Value, key: &str) -> Result<Option<Status>, DomainError> {
     let Some(raw) = str_opt(args, key) else {
         return Ok(None);
@@ -372,26 +350,6 @@ pub(super) fn freshness_opt(
         return Ok(None);
     };
     Ok(Some(raw.parse::<FreshnessState>()?))
-}
-
-pub(super) fn tags_opt(args: &Value) -> Result<Option<Vec<String>>, DomainError> {
-    let Some(raw_tags) = args.get("tags") else {
-        return Ok(None);
-    };
-    let array = raw_tags
-        .as_array()
-        .ok_or_else(|| DomainError::InvalidData("'tags' must be an array of strings".into()))?;
-    let mut tags = Vec::with_capacity(array.len());
-    for item in array {
-        let value = item
-            .as_str()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .ok_or_else(|| DomainError::InvalidData("all tags must be non-empty strings".into()))?
-            .to_string();
-        tags.push(value);
-    }
-    Ok(Some(tags))
 }
 
 #[cfg(test)]

--- a/src/adapters/mcp_stdio/schema.rs
+++ b/src/adapters/mcp_stdio/schema.rs
@@ -14,28 +14,31 @@ pub(super) fn tools_schema() -> Value {
                             "description": "Operation to perform",
                             "enum": ["list", "get", "write", "ttl", "delete"]
                         },
-                        "op": {
-                            "type": "string",
-                            "description": "Write operation kind (v3 transitional router).",
-                            "enum": [
-                                "create",
-                                "upsert_section",
-                                "delete_section",
-                                "upsert_ref",
-                                "delete_ref",
-                                "upsert_diagram",
-                                "set_meta",
-                                "set_status"
-                            ]
-                        },
                         "id": { "type": "string", "description": "Pack ID" },
                         "name": { "type": "string", "description": "Pack name (alternative to id)" },
-                        "title": { "type": "string" },
-                        "brief": { "type": "string", "description": "Short description of the pack" },
-                        "tags": { "type": "array", "items": { "type": "string" } },
-                        "ttl_minutes": { "type": "integer", "description": "TTL from now in minutes. Required for op=create; also used by action=ttl(set)." },
+                        "ttl_minutes": { "type": "integer", "description": "TTL from now in minutes (action=ttl(set))." },
                         "extend_minutes": { "type": "integer", "description": "Extend existing TTL by this many minutes (action=ttl)." },
-                        "expected_revision": { "type": "integer", "description": "Required for mutating actions: write/ttl." },
+                        "expected_revision": { "type": "integer", "description": "Required for update writes and ttl actions." },
+                        "validate_only": {
+                            "type": "boolean",
+                            "description": "When true, input.write validates document and returns diagnostics without persistence."
+                        },
+                        "document": {
+                            "type": "object",
+                            "description": "Full-replace snapshot payload for action=write.",
+                            "properties": {
+                                "name": { "type": "string", "description": "Optional pack name (new pack only, immutable for updates)." },
+                                "title": { "type": "string" },
+                                "brief": { "type": "string", "description": "Short description of the pack" },
+                                "tags": { "type": "array", "items": { "type": "string" } },
+                                "ttl_minutes": { "type": "integer", "description": "Optional TTL override from now in minutes." },
+                                "status": { "type": "string", "enum": ["draft", "finalized"] },
+                                "sections": {
+                                    "type": "array",
+                                    "description": "Full list of sections (each section can include refs and diagrams)."
+                                }
+                            }
+                        },
                         "status": { "type": "string", "enum": ["draft", "finalized"] },
                         "freshness": {
                             "type": "string",
@@ -44,21 +47,7 @@ pub(super) fn tools_schema() -> Value {
                         },
                         "query": { "type": "string", "description": "Text search for list" },
                         "limit": { "type": "integer" },
-                        "offset": { "type": "integer" },
-                        "section_key": { "type": "string", "description": "^[a-z0-9][a-z0-9_-]{1,63}$" },
-                        "section_title": { "type": "string" },
-                        "section_description": { "type": "string" },
-                        "section_order": { "type": "integer" },
-                        "ref_key": { "type": "string", "description": "^[a-z0-9][a-z0-9_-]{1,63}$" },
-                        "ref_title": { "type": "string" },
-                        "ref_why": { "type": "string", "description": "Why this ref matters" },
-                        "path": { "type": "string", "description": "Repo-relative file path" },
-                        "line_start": { "type": "integer", "description": "1-indexed start line" },
-                        "line_end": { "type": "integer", "description": "1-indexed end line" },
-                        "group": { "type": "string", "description": "Group name for ref organization" },
-                        "diagram_key": { "type": "string", "description": "^[a-z0-9][a-z0-9_-]{1,63}$" },
-                        "mermaid": { "type": "string", "description": "Mermaid diagram source" },
-                        "diagram_why": { "type": "string" }
+                        "offset": { "type": "integer" }
                     }
                 }
             },

--- a/src/domain/models.rs
+++ b/src/domain/models.rs
@@ -209,6 +209,10 @@ impl Pack {
         Ok(())
     }
 
+    pub fn ttl_deadline_from_now(minutes: u64, now: DateTime<Utc>) -> Result<DateTime<Utc>> {
+        Ok(now + ttl_duration(minutes)?)
+    }
+
     pub fn is_expired(&self, now: DateTime<Utc>) -> bool {
         self.expires_at <= now
     }


### PR DESCRIPTION
## Summary
- cut `input.write` over to full-replace `document` payloads (+ `validate_only`)
- removed public `op`/granular write contract from schema, parser, tests, and docs
- kept finalize checks fail-closed for normal + validate-only write paths

## Validation
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-targets --all-features
- scripts/check_coverage_baseline.sh
- cargo audit

Refs #83