### PR TITLE
Docs/Skills: refresh context_pack v3 usage pack

### DIFF
--- a/.codex/skills/context-pack-repo-profile/SKILL.md
+++ b/.codex/skills/context-pack-repo-profile/SKILL.md
@@ -1,88 +1,76 @@
 ---
 name: context-pack-repo-profile
-description: "Проектный профиль по работе с context_pack для mcp/context_pack: инварианты, recovery и operator checklist."
+description: "Проектный профиль по работе с context_pack v3 для mcp/context_pack: инварианты, recovery и operator checklist."
 ---
 
-# Context Pack Repo Profile (mcp/context_pack)
+# Context Pack Repo Profile (mcp/context_pack, v3)
 
-## Что это
-Норматив для всех расследований/ревью, где используется `mcp__context_pack` в этом репозитории.
+SSOT для этого репозитория: [TECHNICAL.md](../../../TECHNICAL.md) + v3 реализация в `src/adapters/mcp_stdio/*`, `src/app/*`.
 
----
+Используй этот skill для ежедневной работы через `mcp__context_pack` (explore, orchestration, execution, review).
 
-## Runtime invariants (в рамках SSOT этого репозитория)
+## Hard contract (не обсуждается)
 
-1) **Coverage baseline policy**
-- Baseline хранится в `.github/coverage-baseline.json`.
-- Значение baseline: `line_coverage_percent`.
-- Любая смена policy должна пройти `scripts/check_coverage_baseline.sh` и быть зафиксирована в PR.
-- Порог строгий: `0 < x <= 100`.
+- `input` actions: `list`, `get`, `write`, `ttl`, `delete`
+- `output` actions: `list`, `read`
+- `input.write` только через `document` full-replace snapshot (legacy `upsert_*`, `set_*`, `op` запрещены)
+- update (`input.write` / `input.ttl`) требует `expected_revision`
+- finalize всегда через precheck: `input.write(validate_only=true, document.status=finalized)`
+- handoff между агентами — только с **точным `pack_id`** (`pk_[a-z2-7]{8}`), не по `name`
+- `output.read` routing: `profile=orchestrator|reviewer|executor`, pagination: `page_token`, фильтр: `contains`
 
-2) **Oversize guard**
-- Лимит размера pack-файла по умолчанию — 512 KiB (`CONTEXT_PACK_MAX_PACK_BYTES`, по умолчанию 524288).
-- Oversized payload должен быть rejected до persistence (create/save) с `invalid_data`.
-- Не допускается persistence oversized pack, который ломает последующий list/get.
+## 60-секундный daily path
 
-3) **Unreadable / malformed isolation**
-- Коррумпированный, unreadable или oversized pack на диске не должен «блокировать» все операции.
-- Перечисляющие пути (`input`/`output` list и enumerate) должны удалять такие pack-файлы и продолжать с валидными.
-- TTL purge должен очищать такие файлы.
+1. Найди/проверь pack: `input.list` / `input.get(id)`.
+2. Перед мутацией получи свежий `revision` (`input.get`).
+3. Запиши **полный** snapshot через `input.write`.
+4. Перед finalize: `validate_only=true`.
+5. Коммит finalize (без `validate_only`).
+6. Считай handoff-view: `output.read(id=<pack_id>, profile=orchestrator)`.
+7. Передай дальше: `pack_id + 1-line summary + next action`.
 
-4) **delete_pack recovery**
-- Для точечного восстановления используйте `input(delete_pack)`.
-- Точка восстановления:
-  1. локализовать проблемный `pack_id` (list/output);
-  2. `input` `action: delete_pack` с `id`;
-  3. верифицировать, что оставшиеся healthy packs читаются.
+## Router по references (progressive disclosure)
 
----
+Открывай только нужный файл:
 
-## Operational discipline
+1. [`references/00-v3-contract-cheatsheet.md`](references/00-v3-contract-cheatsheet.md)
+   - copy-paste JSON для всех action'ов v3
+2. [`references/10-daily-workflows.md`](references/10-daily-workflows.md)
+   - потоки Explorer→Orchestrator, Orchestrator→Executor, Reviewer
+3. [`references/20-finalize-qa-freshness.md`](references/20-finalize-qa-freshness.md)
+   - finalize gate, `validate_only`, TTL/freshness дисциплина
+4. [`references/30-recovery-playbook.md`](references/30-recovery-playbook.md)
+   - recovery: `revision_conflict`, `ambiguous`, `expired/expiring_soon`, `stale_ref`
+5. [`references/40-section-templates.md`](references/40-section-templates.md)
+   - каркасы `scope/findings/qa` + optional sections
+6. [`references/50-naming-conventions.md`](references/50-naming-conventions.md)
+   - naming для `section_key/ref_key/group` + contains/search discipline
+7. [`references/60-anti-patterns.md`](references/60-anti-patterns.md)
+   - чего не делать (v2 legacy, partial snapshot, name-handoff и т.д.)
 
-- Применять deterministic read protocol для больших пакетов:
-  - `mode`: `full | compact`;
-  - `limit` + `offset` для первой страницы;
-  - `cursor`/`next` для продолжения.
-- Regex-фильтр `match` обязателен только при необходимости сузить выборку и всегда проверять корректность.
-- Ключевой handoff: `pack_id + <=200 символов summary`.
+## Repo invariants (операционные)
 
----
+- Expired grace window: `CONTEXT_PACK_EXPIRED_GRACE_SECONDS` (default `900`)
+- Oversize guard: `CONTEXT_PACK_MAX_PACK_BYTES` (default `524288`)
+- Corrupted/oversized файлы не должны ломать `list/read`; они изолируются/очищаются
+- CI quality baseline:
+  - `.github/coverage-baseline.json`
+  - `scripts/check_coverage_baseline.sh`
 
-## Operator checklist
+## Минимальный handoff protocol
 
-Для каждой задачи с контекстным сканированием:
-1. `input(list)` (по возможности через query) и/или `output(list)` → зафиксировать стартовый набор
-2. `input(create)` или `input(get)` → получить `revision`.
-3. Вносить факт-секции (`upsert_section`, `upsert_ref`) с anchors.
-4. Подготовить обязательные артефакты для release/мержа:
-   - `pack_id` (finalized),
-   - `review`-comment URL,
-   - `review` verdict (`PASS`/`BLOCKED`),
-   - `@codex` статус: optional/non-blocking (информационный).
-5. На рисках High/Critical требуются минимум:
-   - два anchors **или**
-   - один anchor + независимая контрпроверка.
-6. Перед финишем: `output(get)` и QA gate.
-7. Set status:
-   - `finalized` при полной воспроизводимости;
-   - иначе `draft` + `gaps`.
-8. Перед закрытием issue добавить `PR`, `pack_id`, AC mapping.
+В completion/report обязательно:
 
----
+- `pack_id` (точный)
+- статус пакета (`draft|finalized`)
+- что читать следующим (`profile=orchestrator|reviewer|executor`)
+- при ревью: `review URL + verdict (PASS|BLOCKED)`
 
-## Review handoff protocol (required by issue-55 contract)
-- Default review path: dedicated `review` agent requested from PR via `@review review` (required).
-- Review comment URL and `PASS|BLOCKED` verdict must be captured and posted in completion report.
-- `@codex review` is optional/secondary and never blocking; if unavailable, document fallback explicitly.
-- Review agent loop runs on finalized context pack (`pack_id`) as primary evidence.
+Пример 1 строки:
 
-## AC mapping шаблон для delivery-комментария в issue
+`pack_id=pk_abcd2345 finalized; summary=auth guard root cause verified; next=executor apply fix plan (profile=executor)`
 
-- `global skills` обновлён — да/нет.
-- `repo-local profile` добавлен — да/нет.
-- `global review loop` соблюдён (обязательный `review` loop + `pack_id` + `review comment` URL + `PASS/BLOCKED`).
-- `@codex` учтён как optional/non-blocking — да/нет.
-- Указаны новые output/get параметры (`compact|full`, `limit|offset|cursor|next`, `match`).
-- Указан обязательный review маршрут: `review` агент (required), `@codex` optional, review verdict captured, review comment URL + `pack_id` в completion.
-- QA handoff дисциплина соблюдена (`pack_id + summary`).
-- Тест-гейт выполнен: `cargo fmt --check && cargo test --all-targets --all-features`.
+## Legacy note
+
+Папка `skills/explorer-context-pack/*` в этом репо переведена в LEGACY-режим.
+Для актуальной работы используйте только текущий профиль и его references.

--- a/.codex/skills/context-pack-repo-profile/references/00-v3-contract-cheatsheet.md
+++ b/.codex/skills/context-pack-repo-profile/references/00-v3-contract-cheatsheet.md
@@ -1,0 +1,326 @@
+# v3 Contract Cheat-Sheet (copy/paste)
+
+Источник правды: [TECHNICAL.md](../../../../TECHNICAL.md).
+
+## Allowed actions
+
+- `input`: `list`, `get`, `write`, `ttl`, `delete`
+- `output`: `list`, `read`
+
+> Если видишь `create`, `upsert_*`, `set_*`, `output get`, `delete_pack`, `cursor`, `match`, `mode` — это legacy/v2 и должно быть заменено.
+
+---
+
+## 1) `input.list`
+
+```json
+{
+  "name": "input",
+  "arguments": {
+    "action": "list",
+    "freshness": "fresh",
+    "limit": 20,
+    "offset": 0
+  }
+}
+```
+
+`freshness` опционален: `fresh | expiring_soon | expired`.
+По умолчанию expired скрыты.
+
+---
+
+## 2) `input.get`
+
+```json
+{
+  "name": "input",
+  "arguments": {
+    "action": "get",
+    "id": "pk_abcd2345"
+  }
+}
+```
+
+Используй перед любой мутацией, чтобы взять актуальный `revision`.
+
+---
+
+## 3) `input.write` — create (new pack)
+
+> Create: **не** передаём `id/name` на верхнем уровне и **не** передаём `expected_revision`.
+
+```json
+{
+  "name": "input",
+  "arguments": {
+    "action": "write",
+    "document": {
+      "name": "ctx-auth-login-20260303",
+      "title": "Auth login regression",
+      "brief": "Evidence pack for auth login investigation",
+      "tags": ["auth", "incident", "v3"],
+      "ttl_minutes": 180,
+      "status": "draft",
+      "sections": [
+        {
+          "key": "scope",
+          "title": "Scope",
+          "description": "objective: locate failing auth path and root cause"
+        },
+        {
+          "key": "findings",
+          "title": "Findings",
+          "description": "Root-cause evidence",
+          "refs": [
+            {
+              "key": "auth_guard_01",
+              "path": "src/auth/guard.rs",
+              "line_start": 41,
+              "line_end": 74,
+              "title": "Login guard early-return",
+              "why": "Missing token fallback branch",
+              "group": "auth/login"
+            }
+          ]
+        },
+        {
+          "key": "qa",
+          "title": "QA",
+          "description": "verdict: pending"
+        }
+      ]
+    }
+  }
+}
+```
+
+---
+
+## 4) `input.write` — update existing pack
+
+> Update: нужен `id` (или `name`) + `expected_revision`.
+> Для детерминизма и handoff всегда используй `id`.
+
+```json
+{
+  "name": "input",
+  "arguments": {
+    "action": "write",
+    "id": "pk_abcd2345",
+    "expected_revision": 7,
+    "document": {
+      "name": "ctx-auth-login-20260303",
+      "title": "Auth login regression",
+      "brief": "Evidence pack for auth login investigation",
+      "tags": ["auth", "incident", "v3"],
+      "ttl_minutes": 240,
+      "status": "draft",
+      "sections": [
+        {
+          "key": "scope",
+          "title": "Scope",
+          "description": "objective: locate failing auth path and root cause"
+        },
+        {
+          "key": "findings",
+          "title": "Findings",
+          "description": "Updated findings after rerun",
+          "refs": [
+            {
+              "key": "auth_guard_01",
+              "path": "src/auth/guard.rs",
+              "line_start": 41,
+              "line_end": 74,
+              "title": "Login guard early-return",
+              "why": "Token fallback still missing",
+              "group": "auth/login"
+            },
+            {
+              "key": "session_flow_02",
+              "path": "src/auth/session.rs",
+              "line_start": 10,
+              "line_end": 39,
+              "title": "Session init path",
+              "why": "Shows expected branch",
+              "group": "auth/session"
+            }
+          ]
+        },
+        {
+          "key": "qa",
+          "title": "QA",
+          "description": "verdict: pending"
+        }
+      ]
+    }
+  }
+}
+```
+
+`input.write` — full-replace snapshot: если секцию не включить в `document.sections`, она исчезнет.
+
+---
+
+## 5) Finalize precheck (`validate_only=true`) — обязательный gate
+
+```json
+{
+  "name": "input",
+  "arguments": {
+    "action": "write",
+    "id": "pk_abcd2345",
+    "expected_revision": 8,
+    "validate_only": true,
+    "document": {
+      "name": "ctx-auth-login-20260303",
+      "title": "Auth login regression",
+      "brief": "Ready for finalize",
+      "tags": ["auth", "incident", "v3"],
+      "ttl_minutes": 240,
+      "status": "finalized",
+      "sections": [
+        { "key": "scope", "title": "Scope", "description": "objective: ..." },
+        { "key": "findings", "title": "Findings", "description": "evidence: ..." },
+        { "key": "qa", "title": "QA", "description": "verdict: pass" }
+      ]
+    }
+  }
+}
+```
+
+---
+
+## 6) Finalize commit (persist)
+
+```json
+{
+  "name": "input",
+  "arguments": {
+    "action": "write",
+    "id": "pk_abcd2345",
+    "expected_revision": 8,
+    "document": {
+      "name": "ctx-auth-login-20260303",
+      "title": "Auth login regression",
+      "brief": "Ready for finalize",
+      "tags": ["auth", "incident", "v3"],
+      "ttl_minutes": 240,
+      "status": "finalized",
+      "sections": [
+        { "key": "scope", "title": "Scope", "description": "objective: ..." },
+        { "key": "findings", "title": "Findings", "description": "evidence: ..." },
+        { "key": "qa", "title": "QA", "description": "verdict: pass" }
+      ]
+    }
+  }
+}
+```
+
+---
+
+## 7) `input.ttl` (set/extend)
+
+```json
+{
+  "name": "input",
+  "arguments": {
+    "action": "ttl",
+    "id": "pk_abcd2345",
+    "expected_revision": 9,
+    "extend_minutes": 120
+  }
+}
+```
+
+Ровно одно из полей: `ttl_minutes` или `extend_minutes`.
+
+---
+
+## 8) `input.delete`
+
+```json
+{
+  "name": "input",
+  "arguments": {
+    "action": "delete",
+    "id": "pk_abcd2345"
+  }
+}
+```
+
+---
+
+## 9) `output.list`
+
+```json
+{
+  "name": "output",
+  "arguments": {
+    "action": "list",
+    "freshness": "expired"
+  }
+}
+```
+
+---
+
+## 10) `output.read` — orchestrator compact (default)
+
+```json
+{
+  "name": "output",
+  "arguments": {
+    "action": "read",
+    "id": "pk_abcd2345",
+    "profile": "orchestrator"
+  }
+}
+```
+
+---
+
+## 11) `output.read` — reviewer full evidence
+
+```json
+{
+  "name": "output",
+  "arguments": {
+    "action": "read",
+    "id": "pk_abcd2345",
+    "profile": "reviewer"
+  }
+}
+```
+
+---
+
+## 12) `output.read` — executor + contains + paging
+
+```json
+{
+  "name": "output",
+  "arguments": {
+    "action": "read",
+    "id": "pk_abcd2345",
+    "profile": "executor",
+    "contains": "auth/login",
+    "limit": 8
+  }
+}
+```
+
+Продолжение по `next_page_token` из LEGEND:
+
+```json
+{
+  "name": "output",
+  "arguments": {
+    "action": "read",
+    "id": "pk_abcd2345",
+    "page_token": "<next_page_token_from_legend>"
+  }
+}
+```
+
+`contains` — case-insensitive substring filter (не regex).

--- a/.codex/skills/context-pack-repo-profile/references/10-daily-workflows.md
+++ b/.codex/skills/context-pack-repo-profile/references/10-daily-workflows.md
@@ -1,0 +1,73 @@
+# Daily workflows (repo-specific)
+
+Цель: быстро передавать фактический контекст между ролями без повторного сканирования кода.
+
+## A) Explorer → Orchestrator
+
+1. **Создай/найди draft pack**
+   - `input.list` (query/freshness)
+   - при отсутствии: `input.write` create
+2. **Собери фактуру в sections/refs**
+   - цикл: `input.get(id)` → взять `revision` → `input.write(id, expected_revision, document)`
+3. **Пройди finalize gate**
+   - `input.write(validate_only=true, document.status=finalized)`
+   - исправь ошибки (`missing_sections`, `missing_fields`, `invalid_refs`)
+4. **Сделай finalize commit**
+   - `input.write(..., document.status=finalized)`
+5. **Сними handoff-view для оркестратора**
+   - `output.read(id, profile=orchestrator)`
+6. **Передай в чат строго**
+   - `pack_id` (exact)
+   - `status`
+   - 1-line summary
+   - next action
+
+Шаблон сообщения:
+
+`pack_id=pk_abcd2345 finalized; summary=auth fallback root cause confirmed; next=orchestrator route fix owner`
+
+---
+
+## B) Orchestrator → Executor
+
+1. Orchestrator читает:
+   - `output.read(id, profile=orchestrator)`
+2. Выбирает executable slice и передаёт **тот же pack_id** executor'у.
+3. Executor читает:
+   - `output.read(id, profile=executor)`
+   - при необходимости фокус: `contains="<token>"`
+4. Если executor дополняет фактуру:
+   - `input.get(id)` → `revision`
+   - `input.write(id, expected_revision, updated document)`
+5. Перед merge/close:
+   - если статус должен быть finalized, снова пройти `validate_only` gate.
+
+Практика: orchestration и execution не создают новый pack без причины; сначала переиспользуют текущий `pack_id`.
+
+---
+
+## C) Reviewer workflow
+
+1. Reviewer читает полный evidence:
+   - `output.read(id, profile=reviewer)`
+2. Проверяет:
+   - есть ли anchors для ключевых выводов
+   - нет ли `stale ref` в рендере
+   - есть ли `qa` c `verdict`
+3. Для прицельного просмотра:
+   - `output.read(id, profile=reviewer, contains="<finding-token>")`
+4. Итог review:
+   - `PASS` или `BLOCKED`
+   - список обязательных доработок (если BLOCKED)
+5. В completion/review comment обязательно:
+   - `pack_id`
+   - review URL
+   - verdict
+
+---
+
+## Fast role map
+
+- `profile=orchestrator`: компактный handoff-first обзор (default limit bounded)
+- `profile=executor`: компактный actionable обзор
+- `profile=reviewer`: полный markdown с evidence/snippets

--- a/.codex/skills/context-pack-repo-profile/references/20-finalize-qa-freshness.md
+++ b/.codex/skills/context-pack-repo-profile/references/20-finalize-qa-freshness.md
@@ -1,0 +1,70 @@
+# Finalize / QA gate + Freshness/TTL discipline
+
+## 1) Finalize gate (fail-closed)
+
+Перед `status=finalized` обязательно:
+
+- есть секция `scope` и в ней есть content (description/ref/diagram)
+- есть секция `findings` и в ней есть content
+- есть секция `qa`, содержащая `verdict` (например, `verdict: pass`)
+- все refs резолвятся (нет stale/broken anchors)
+
+Если нет — ошибка `code=finalize_validation` с деталями:
+
+- `missing_sections`
+- `missing_fields`
+- `invalid_refs`
+
+## 2) Обязательная последовательность finalize
+
+1. `input.get(id)` → взять актуальный `revision`
+2. `input.write(validate_only=true, document.status=finalized)`
+3. Исправить найденные проблемы
+4. `input.get(id)` снова (если были правки)
+5. `input.write(..., document.status=finalized)` (persist)
+6. `output.read(id, profile=orchestrator)` — sanity check handoff
+
+`validate_only=true` не должен менять persisted state и revision.
+
+---
+
+## 3) Freshness/TTL discipline (ежедневно)
+
+### Freshness states
+
+- `fresh`
+- `expiring_soon` (<= 15 минут до TTL deadline)
+- `expired`
+
+### Базовые правила
+
+- На create всегда ставь осмысленный `document.ttl_minutes`.
+- Перед handoff/ревью проверяй `freshness_state` через `output.read` LEGEND.
+- Если `expiring_soon` и пак нужен дальше — продли TTL через `input.ttl`.
+- `expired` по умолчанию скрыт в `list`; для диагностики используй `freshness=expired`.
+
+### Продление TTL (без потери контекста)
+
+1. `input.get(id)` → взять `revision`
+2. `input.ttl(id, expected_revision, extend_minutes=...)`
+3. Проверить `freshness_state` через `input.get`/`output.read`
+
+---
+
+## 4) Expired grace window
+
+- `CONTEXT_PACK_EXPIRED_GRACE_SECONDS` (default `900`)
+- Внутри grace expired pack ещё может читаться по exact `id` (`input.get` / `output.read`).
+- Чтобы увидеть expired packs в list, используй `freshness=expired` (иначе expired скрыты по умолчанию).
+- После grace: ожидаем purge/not_found (не рассчитывай на восстановление старого id)
+
+---
+
+## 5) QA quick checklist перед handoff
+
+- [ ] `status` ожидаемый (`draft|finalized`)
+- [ ] `scope/findings/qa` присутствуют и содержательны
+- [ ] `qa` содержит `verdict`
+- [ ] нет stale refs
+- [ ] `freshness_state != expired` (или explicitly acknowledged)
+- [ ] handoff содержит exact `pack_id`

--- a/.codex/skills/context-pack-repo-profile/references/30-recovery-playbook.md
+++ b/.codex/skills/context-pack-repo-profile/references/30-recovery-playbook.md
@@ -1,0 +1,77 @@
+# Recovery playbook (v3)
+
+Глобальный retry budget: максимум 3 повтора на один тип сбоя, затем `BLOCKED` с причиной и evidence.
+
+## 1) `revision_conflict`
+
+**Сигнал**
+
+- `code=revision_conflict`
+- в details есть `expected_revision`, `current_revision`, `last_updated_at`, `changed_section_keys`, `guidance`
+
+**Что делать**
+
+1. `input.get(id)` — получить актуальный `revision`
+2. Смерджить намерение с изменениями из `changed_section_keys`
+3. Повторить `input.write`/`input.ttl` с новым `expected_revision=current_revision`
+4. Если конфликт повторяется >3 раз — `BLOCKED` и эскалация владельцу pack
+
+---
+
+## 2) `ambiguous` (обычно при чтении по `name`)
+
+**Сигнал**
+
+- `code=ambiguous`
+- в details: `candidate_ids`
+
+**Что делать**
+
+1. Возьми `candidate_ids` из ошибки
+2. Повтори `output.read` по точному `id` (не по name)
+3. Зафиксируй выбранный `pack_id` в handoff
+4. Дальше работай только с этим `id`
+
+Профилактика: межагентный handoff всегда по exact `pack_id`.
+
+---
+
+## 3) `expired` / `expiring_soon`
+
+### `expiring_soon`
+
+1. `input.get(id)` → взять `revision`
+2. `input.ttl(id, expected_revision, extend_minutes=...)`
+3. Проверить обновлённый `freshness_state`
+
+### `expired`
+
+1. `input.list(freshness=expired)` или `output.list(freshness=expired)`
+2. Если pack ещё в grace window — быстро снять нужные данные через `output.read(id)`
+3. Если not_found/после purge — создать новый pack через `input.write` create
+4. В новом pack в `qa`/`scope` явно указать связь: `replaces: <old_pack_id>`
+
+---
+
+## 4) `stale_ref`
+
+**Сигнал**
+
+- предупреждение `> stale ref: ...` в output
+- либо `finalize_validation` с `invalid_refs`
+
+**Что делать**
+
+1. Исправить `path`/`line_start`/`line_end` в snapshot
+2. Если anchor больше не релевантен — удалить ref из `document`
+3. Повторить `input.write` (draft)
+4. Повторить finalize precheck (`validate_only=true`)
+
+---
+
+## 5) Быстрый triage-алгоритм
+
+1. Классифицируй ошибку (`validation|conflict|not_found|stale_ref|invalid_state`)
+2. Восстанови консистентность (`get revision`, `exact id`, `freshness check`)
+3. Повтори только один шаг пайплайна, не весь workflow
+4. Зафиксируй итог в `qa.description` (что сломалось/как восстановили)

--- a/.codex/skills/context-pack-repo-profile/references/40-section-templates.md
+++ b/.codex/skills/context-pack-repo-profile/references/40-section-templates.md
@@ -1,0 +1,121 @@
+# Section templates (v3 snapshot)
+
+Ниже — шаблоны для `document.sections` в `input.write`.
+
+## 1) Минимум для finalize
+
+```json
+[
+  {
+    "key": "scope",
+    "title": "Scope",
+    "description": "objective: <что проверяем>; in_scope: <границы>; out_of_scope: <что исключено>"
+  },
+  {
+    "key": "findings",
+    "title": "Findings",
+    "description": "summary: <главный вывод>",
+    "refs": [
+      {
+        "key": "finding_core_01",
+        "path": "src/module/file.rs",
+        "line_start": 10,
+        "line_end": 34,
+        "title": "Core finding anchor",
+        "why": "Evidence for <claim>",
+        "group": "module/flow"
+      }
+    ]
+  },
+  {
+    "key": "qa",
+    "title": "QA",
+    "description": "verdict: pass; checks: <what was validated>; notes: <residual caveats>"
+  }
+]
+```
+
+> В `qa` должен присутствовать токен `verdict` (в title/description/ref/diagram).
+
+---
+
+## 2) Recommended extended layout
+
+```json
+[
+  { "key": "scope", "title": "Scope", "description": "objective: ..." },
+  { "key": "findings", "title": "Findings", "description": "summary: ..." },
+  { "key": "risks", "title": "Risks", "description": "R1: ...; R2: ..." },
+  { "key": "gaps", "title": "Gaps", "description": "missing evidence: ..." },
+  { "key": "next_steps", "title": "Next steps", "description": "owner: ...; action: ..." },
+  { "key": "qa", "title": "QA", "description": "verdict: pass|blocked; checks: ..." }
+]
+```
+
+---
+
+## 3) Reviewer-oriented findings block
+
+```json
+{
+  "key": "findings",
+  "title": "Findings",
+  "description": "FND-auth-01: token fallback missing",
+  "refs": [
+    {
+      "key": "auth_fallback_01",
+      "path": "src/auth/guard.rs",
+      "line_start": 41,
+      "line_end": 74,
+      "title": "FND-auth-01 anchor",
+      "why": "Explains why unauthenticated branch exits early",
+      "group": "auth/login"
+    },
+    {
+      "key": "auth_fallback_02",
+      "path": "src/auth/session.rs",
+      "line_start": 10,
+      "line_end": 39,
+      "title": "FND-auth-01 cross-check",
+      "why": "Shows expected behavior path",
+      "group": "auth/session"
+    }
+  ]
+}
+```
+
+---
+
+## 4) QA section template (pass/blocked)
+
+### PASS
+
+```json
+{
+  "key": "qa",
+  "title": "QA",
+  "description": "verdict: pass; finalize_precheck: passed; stale_refs: none"
+}
+```
+
+### BLOCKED
+
+```json
+{
+  "key": "qa",
+  "title": "QA",
+  "description": "verdict: blocked; blocker: missing anchor for FND-auth-02; next: collect ref in src/auth/policy.rs"
+}
+```
+
+---
+
+## 5) Optional sections (when useful)
+
+- `constraints` — внешние контракты/ограничения
+- `decision_log` — принятые решения и причины
+- `migration_plan` — поэтапная миграция
+- `acceptance_checks` — чеклист проверок
+- `handoff` — кого и с чем маршрутизировать дальше
+
+Держи ключи короткими, стабильными, lowercase snake/kebab.

--- a/.codex/skills/context-pack-repo-profile/references/50-naming-conventions.md
+++ b/.codex/skills/context-pack-repo-profile/references/50-naming-conventions.md
@@ -1,0 +1,78 @@
+# Naming conventions (`section_key`, `ref_key`, `group`)
+
+Цель: стабилизировать структуру пакета и сделать фильтрацию/навигацию предсказуемой.
+
+## 1) `section_key` / `ref_key` / `diagram.key` format
+
+Валидатор ключей: `^[a-z0-9][a-z0-9_-]{1,63}$`
+
+Практика:
+
+- только lowercase
+- длина 2..64
+- без пробелов/кириллицы/точек
+- стабильные ключи (не переименовывай без необходимости)
+
+Примеры:
+
+- section: `scope`, `findings`, `qa`, `next_steps`
+- ref: `auth_guard_01`, `session_flow_02`, `risk_token_expiry_01`
+- diagram: `flow_login_01`
+
+---
+
+## 2) Рекомендуемая семантика ключей
+
+### Section keys
+
+- `scope`, `findings`, `qa` — baseline для finalize
+- optional: `risks`, `gaps`, `constraints`, `next_steps`, `acceptance_checks`
+
+### Ref keys
+
+Шаблон: `<area>_<topic>_<nn>`
+
+- `auth_fallback_01`
+- `storage_purge_02`
+- `api_contract_03`
+
+### Group names (`ref.group`)
+
+`group` — произвольная строка для рендера групп (`### group: ...`).
+
+Рекомендуемый шаблон: `<domain>/<subsystem>`
+
+- `auth/login`
+- `auth/session`
+- `storage/purge`
+- `mcp/output`
+
+---
+
+## 3) Как сделать `contains` действительно полезным
+
+Важно: server-side `contains` ориентирован на отрендеренный chunk-текст (title/why/path/snippet/diagram text).
+
+Поэтому:
+
+1. Ключевой токен дублируй в `ref.title` или `ref.why`.
+2. Для findings используй стабильные маркеры вида `FND-auth-01`.
+3. Дублируй маркер в `qa.description` для итогового поиска.
+4. Не рассчитывай только на `section_key/ref_key` как единственный search token.
+
+Пример:
+
+- `ref_key = auth_fallback_01`
+- `ref.title = "FND-auth-01 anchor"`
+- `ref.why = "FND-auth-01 confirms missing fallback"`
+
+Тогда `contains="FND-auth-01"` работает детерминированно.
+
+---
+
+## 4) Handoff naming discipline
+
+- В handoff всегда писать exact `pack_id`.
+- Не передавать только `name`, если есть несколько одноимённых пакетов.
+- Если pack recreated после expiry, явно указывать связь:
+  - `replaces: pk_old1234`

--- a/.codex/skills/context-pack-repo-profile/references/60-anti-patterns.md
+++ b/.codex/skills/context-pack-repo-profile/references/60-anti-patterns.md
@@ -1,0 +1,38 @@
+# Anti-patterns (не делать)
+
+## Contract violations
+
+1. Использовать v2 действия: `create`, `upsert_*`, `set_*`, `touch_ttl`, `output get`.
+2. Использовать `delete_pack` вместо `input {"action":"delete"}`.
+3. Передавать `mode/cursor/match/format` в `output.read`.
+
+## Consistency violations
+
+4. Писать update без `expected_revision`.
+5. Делать partial snapshot (`input.write`) и случайно удалять секции.
+6. Финализировать без `validate_only=true` precheck.
+7. Игнорировать `invalid_refs`/`stale ref` перед finalize.
+
+## Handoff / collaboration mistakes
+
+8. Передавать pack по `name`, а не по точному `pack_id`.
+9. Не фиксировать `review URL + verdict` в completion.
+10. Хранить факты в чате вместо refs/sections в пакете.
+
+## Freshness mistakes
+
+11. Игнорировать `expiring_soon` и терять контекст по TTL.
+12. Не проверять `freshness=expired`, когда pack «исчез» из default list.
+
+## Search quality mistakes
+
+13. Ожидать regex-поиск от `contains`.
+14. Не дублировать finding-токены (`FND-*`) в `ref.title/ref.why`.
+
+## Smell: переусложнение
+
+15. Секции с длинным narrative без anchors.
+16. Десятки неструктурированных refs без группировки `group`.
+
+Если замечен любой пункт выше — остановись, вернись к
+`00-v3-contract-cheatsheet.md` и приведи pack к v3 discipline.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ For the full tool contract, paging, profiles, error codes, and migration notes �
 - `not_found` — pack has likely expired by TTL.
 - `tool output too large` — split the pack into smaller sections.
 - `ambiguous` — name matched multiple packs; use exact `id` from `details.candidate_ids`.
-- Corrupted or oversized pack files are removed automatically during list operations. To remove a specific pack: `input { "action": "delete_pack", "id": "<pack_id>" }`.
+- Corrupted or oversized pack files are removed automatically during list operations. To remove a specific pack: `input { "action": "delete", "id": "<pack_id>" }`.
 
 ---
 
@@ -417,7 +417,7 @@ Compact handoff-чтение (по умолчанию — bounded, профил�
 - `not_found` — пакет, скорее всего, истёк по TTL.
 - `tool output too large` — разбейте пакет на более мелкие секции.
 - `ambiguous` — имя совпало с несколькими пакетами; используйте точный `id` из `details.candidate_ids`.
-- Повреждённые или oversized-файлы пакетов удаляются автоматически при операциях list. Для точечного удаления: `input { "action": "delete_pack", "id": "<pack_id>" }`.
+- Повреждённые или oversized-файлы пакетов удаляются автоматически при операциях list. Для точечного удаления: `input { "action": "delete", "id": "<pack_id>" }`.
 
 ---
 

--- a/skills/explorer-context-pack/SKILL.md
+++ b/skills/explorer-context-pack/SKILL.md
@@ -1,48 +1,29 @@
 ---
 name: explorer-context-pack
-description: "Операционный skill для реальных проектов: как агентам (explorer/deep_explorer/reviewer) собирать и передавать фактический контекст через mcp__context_pack (input/output), с ревизиями, TTL, QA gate и строгим handoff."
+description: "LEGACY (v2) skill. Deprecated for this repository. Use .codex/skills/context-pack-repo-profile (v3)."
 ---
 
-# Explorer Context Pack Skill (Project Mode)
+# ⚠ explorer-context-pack — LEGACY (deprecated)
 
-Цель: передавать **фактический контекст из кода**, а не мнение. Вся «масса» — внутри context-pack, в чат — только `pack_id + summary`.
+Этот skill-пакет сохранён только для исторического контекста и **не должен использоваться**
+для ежедневной работы в `mcp/context_pack`.
 
----
+Причина: содержимое было написано под v2 (`create/upsert_*/output get`) и противоречит
+каноническому v3 контракту.
 
-## Минимальный путь (для реальных задач)
+## Что использовать вместо него
 
-1) `input(list)` → выбрать/создать pack (`create` с `ttl_minutes`).
-2) `get` → взять `revision` → `upsert_section/ref/diagram` с `expected_revision`.
-3) `output(get)` → самопроверка читаемости.
-4) QA gate → `finalized` или `draft + gaps`.
-5) Handoff в чат: `pack_id + summary <= 200 символов`.
+- Canonical repo-local skill:
+  - [`../../.codex/skills/context-pack-repo-profile/SKILL.md`](../../.codex/skills/context-pack-repo-profile/SKILL.md)
+- Основной контракт:
+  - [`../../TECHNICAL.md`](../../TECHNICAL.md)
 
----
+## Быстрый migration map (v2 -> v3)
 
-## Hard rules (fail‑closed)
+- `input.create` -> `input.write(document=...)` (create)
+- `upsert_section/ref/diagram` -> `input.write(document full snapshot)`
+- `set_status` -> `input.write(document.status=...)`
+- `touch_ttl` -> `input.ttl(ttl_minutes|extend_minutes, expected_revision)`
+- `output.get` -> `output.read`
 
-- Если агент исследует код/архитектуру/риски — skill обязателен.
-- Канал данных: только `mcp__context_pack__input/output`.
-- Никаких «простыней» в чат: все доказательства только в пакете.
-- Summary: **1 строка, <=200 символов**, иначе результат невалиден.
-
----
-
-## Когда читать reference‑файлы
-
-- **actions.md** → точные обязательные поля по действиям.
-- **qa-dod.md** → QA gate, finalized/draft, Critical/High требования.
-- **recovery.md** → что делать при `revision_conflict/expired/not_found/stale_ref`.
-- **role-modes.md** → Explorer / Deep / Reviewer + batch‑ритм.
-- **examples.md** → каркасы секций для bug/review/feature задач.
-- **troubleshooting.md** → частые DX‑проблемы (ttl, size‑limit, stale refs).
-
----
-
-## DoD (минимум)
-
-- Есть валидный `pack_id`.
-- Summary в лимите и по делу.
-- В пакете достаточно доказательств, чтобы оркестратор **не** повторял рескан кода.
-
-Если не выполнено — `draft` или `BLOCKED` с причиной.
+Если у тебя в промпте/шаблоне встречается v2-глагол — перепиши на v3 перед выполнением.

--- a/skills/explorer-context-pack/references/actions.md
+++ b/skills/explorer-context-pack/references/actions.md
@@ -1,24 +1,23 @@
-# actions.md — обязательные поля
+# LEGACY notice: actions.md
 
-| tool | action | обязательные поля |
-|---|---|---|
-| input | list | `action` |
-| input | create | `action`, `ttl_minutes` |
-| input | get | `action`, `id|name` |
-| input | upsert_section | `action`, `id|name`, `expected_revision`, `section_key`, `section_title` |
-| input | delete_section | `action`, `id|name`, `expected_revision`, `section_key` |
-| input | upsert_ref | `action`, `id|name`, `expected_revision`, `section_key`, `ref_key`, `path`, `line_start`, `line_end` |
-| input | delete_ref | `action`, `id|name`, `expected_revision`, `section_key`, `ref_key` |
-| input | upsert_diagram | `action`, `id|name`, `expected_revision`, `section_key`, `diagram_key`, `title`, `mermaid` |
-| input | set_meta | `action`, `id|name`, `expected_revision`, минимум одно: `title|brief|tags` |
-| input | set_status | `action`, `id|name`, `expected_revision`, `status` |
-| input | touch_ttl | `action`, `id|name`, `expected_revision`, ровно одно: `ttl_minutes` или `extend_minutes` |
-| output | list | `action` |
-| output | get | `action`, `id|name` |
+Этот файл больше не описывает актуальный контракт.
 
-Канонические поля (алиасы запрещены):
-- `section_title`, `section_description`
-- `ref_title`, `ref_why`
-- `diagram_why`
+Используй:
 
-`output` всегда markdown, `format` не передавать.
+- `../../../.codex/skills/context-pack-repo-profile/references/00-v3-contract-cheatsheet.md`
+- `../../../TECHNICAL.md`
+
+## v2 -> v3 map
+
+| Legacy (не использовать) | v3 replacement |
+|---|---|
+| `input create` | `input write` (create snapshot) |
+| `upsert_section` / `upsert_ref` / `upsert_diagram` | `input write` (full document snapshot) |
+| `set_meta` / `set_status` | `input write` |
+| `touch_ttl` | `input ttl` |
+| `output get` | `output read` |
+
+Актуальные action'ы v3:
+
+- `input`: `list|get|write|ttl|delete`
+- `output`: `list|read`

--- a/skills/explorer-context-pack/references/examples.md
+++ b/skills/explorer-context-pack/references/examples.md
@@ -1,25 +1,12 @@
-# examples.md — каркасы секций
+# LEGACY notice: examples.md
 
-## A) Bug/incident investigation
-- `scope`
-- `symptoms`
-- `root-cause-hypotheses`
-- `evidence`
-- `fix-options`
-- `verification`
+Примеры из legacy skill-пака не являются каноничными для v3.
 
-## B) Code/PR review
-- `scope_confirmed`
-- `scorecard`
-- `findings`
-- `risks`
-- `reprioritization`
-- `final_verdict`
+Используй вместо этого:
 
-## C) Feature discovery / implementation prep
-- `current_state`
-- `target_behavior`
-- `constraints/contracts`
-- `touch_points`
-- `migration_plan`
-- `acceptance_checks`
+- section templates:
+  - `../../../.codex/skills/context-pack-repo-profile/references/40-section-templates.md`
+- daily workflows:
+  - `../../../.codex/skills/context-pack-repo-profile/references/10-daily-workflows.md`
+- v3 contract examples:
+  - `../../../.codex/skills/context-pack-repo-profile/references/00-v3-contract-cheatsheet.md`

--- a/skills/explorer-context-pack/references/qa-dod.md
+++ b/skills/explorer-context-pack/references/qa-dod.md
@@ -1,24 +1,10 @@
-# qa-dod.md — QA gate и DoD
+# LEGACY notice: qa-dod.md
 
-## QA gate перед finalize
+Этот файл заменён актуальным v3 guidance.
 
-Финализировать можно только если:
-- каждый важный вывод имеет anchor (`path:start-end`);
-- нет `stale_ref`;
-- нет противоречий между секциями;
-- output читаемый и самодостаточный.
+Используй:
 
-## Усиления для реальных проектов
+- `../../../.codex/skills/context-pack-repo-profile/references/20-finalize-qa-freshness.md`
+- `../../../TECHNICAL.md#finalize-checklist-fail-closed`
 
-- любой Critical/High вывод:
-  - минимум 2 anchors, **или**
-  - 1 anchor + независимая контрпроверка;
-- у каждого High/Critical есть `fix + validation`;
-- при неопределённости → не финализировать (`draft + gaps`).
-
-## DoD
-
-- scope покрыт;
-- ключевые выводы подтверждены anchors;
-- summary валиден;
-- pack пригоден для действий без повторного рескана кода.
+Ключевой v3 принцип: finalize только после `input.write(validate_only=true, document.status=finalized)` precheck.

--- a/skills/explorer-context-pack/references/recovery.md
+++ b/skills/explorer-context-pack/references/recovery.md
@@ -1,23 +1,7 @@
-# recovery.md — типовые ошибки
+# LEGACY notice: recovery.md
 
-Глобальный retry‑budget: максимум 3 попытки на тип операции, затем `BLOCKED`.
+Актуальный recovery playbook для v3 перенесён в repo-local canonical skill:
 
-- `revision_conflict`:
-  1) `get` → новый `revision`;
-  2) повторить мутацию;
-  3) после 3 попыток → `BLOCKED`.
+- `../../../.codex/skills/context-pack-repo-profile/references/30-recovery-playbook.md`
 
-- `not_found`:
-  1) проверить `id|name`;
-  2) `list` → выбрать корректный;
-  3) если нет — `create` (если допустимо scope).
-
-- `expired`:
-  1) найти по `name`;
-  2) если удалён — `create` новый;
-  3) вернуть новый `pack_id`.
-
-- `stale_ref`:
-  1) исправить `path/lines` или `delete_ref`;
-  2) повторить QA;
-  3) если не снимается → `draft + gaps`.
+В legacy версии встречались v2-операции; не применять в текущем репозитории.

--- a/skills/explorer-context-pack/references/role-modes.md
+++ b/skills/explorer-context-pack/references/role-modes.md
@@ -1,22 +1,7 @@
-# role-modes.md — режимы ролей
+# LEGACY notice: role-modes.md
 
-### Explorer (быстрый)
-- Узкий scope, минимум шагов.
-- Обычно 3–10 anchors.
+Ролевые режимы для context_pack v3 поддерживаются в:
 
-### Deep Explorer (глубокий)
-- Широкое покрытие + edge‑cases.
-- Обычно 10+ anchors, при необходимости диаграммы.
-- Обязателен блок risks/gaps/next checks.
+- `../../../.codex/skills/context-pack-repo-profile/references/10-daily-workflows.md`
 
-### Reviewer
-- Только узкий валидный scope; иначе `BLOCKED`.
-- Findings обязаны иметь REF + evidence + fix + validation.
-
-## Batch‑ритм (скорость без потери качества)
-
-Разрешено собирать несколько якорей за цикл:
-1) `get revision`
-2) серия `upsert_ref`
-3) промежуточный `output get`
-4) следующая серия
+Причина deprecation: legacy-mode ссылался на v2 действия (`upsert_*`, `output get`).

--- a/skills/explorer-context-pack/references/troubleshooting.md
+++ b/skills/explorer-context-pack/references/troubleshooting.md
@@ -1,6 +1,10 @@
-# troubleshooting.md — частые проблемы
+# LEGACY notice: troubleshooting.md
 
-- `revision_conflict` → перечитать pack (`get`), обновить `expected_revision`.
-- `stale_ref` → поправить `path/lines` или удалить ref.
-- `not_found` → pack мог истечь по TTL.
-- `tool output too large` → разбить пакет на меньшие секции (output ограничен по размеру).
+Для актуальной диагностики v3 используй:
+
+- recovery playbook:
+  - `../../../.codex/skills/context-pack-repo-profile/references/30-recovery-playbook.md`
+- finalize + freshness discipline:
+  - `../../../.codex/skills/context-pack-repo-profile/references/20-finalize-qa-freshness.md`
+
+Legacy troubleshooting-советы не считаются нормативом для этого репозитория.


### PR DESCRIPTION
Closes #85.

## What changed
- Upgraded canonical repo-local skill: `.codex/skills/context-pack-repo-profile` (lean router + hard v3 contract).
- Added progressive-disclosure references with copy/paste v3 examples:
  - v3 contract cheat-sheet
  - daily multi-agent workflows
  - finalize/QA + TTL/freshness discipline
  - recovery playbook
  - section templates
  - naming conventions for deterministic `contains`
  - anti-patterns
- Deprecated legacy v2 skill pack under `skills/explorer-context-pack/*` (kept only as migration map).
- Fixed README troubleshooting example: `delete_pack` -> v3 `delete`.

## Why
Prevent agents from using legacy verbs/actions and make handoffs deterministic + low-noise (pack-first, exact `pack_id`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Upgraded Context Pack profile from v2 to v3 with streamlined, workflow-oriented documentation.
  * Added comprehensive v3 guides including contract specifications, daily workflows, QA/finalize procedures, recovery playbooks, section templates, naming conventions, and anti-pattern guidance.
  * Deprecated v2 context pack in favor of v3; included migration guidance mapping.

* **Bug Fixes**
  * Corrected action naming in delete operation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->